### PR TITLE
refactor: graph storage overhaul, clone API, arc ID management, and rows rename

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "rcspp"
-version = "0.0.2.dev0"
+version = "0.0.2.dev1"
 description = "Resource Constrained Shortest Path Problem library with C++ and Python bindings."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/python/test_clone.py
+++ b/src/python/test_clone.py
@@ -1,0 +1,566 @@
+#  Copyright (c) 2025 Laboratory for Combinatorial Optimization in Real-time Environment.
+#  All rights reserved.
+
+"""Tests for ResourceGraph.clone, clone_topology, add_rows_to_arc, and add_rows.
+
+Covers:
+- add_arc with dual_rows as a single tuple (index, coeff) or list of tuples
+- next_arc_id() returns the expected next arc ID
+- add_rows_to_arc buffers rows and flushes them correctly
+- add_rows adds rows in bulk from a list of triples or a 2-D numpy array
+- update_reduced_costs uses stored dual rows to compute reduced costs
+- clone() produces an independent copy with stable arc IDs and preserved rows
+- clone_topology() produces an independent copy with empty dual rows
+- clone_removed_arcs=True preserves removed arcs in the clone
+- Removing arcs in a clone does not affect the original graph
+"""
+
+import math
+import os
+import sys
+
+import numpy as np
+relative_path = "../python_interface/"
+sys.path.insert(0, os.path.abspath(relative_path))
+
+from rcspp.graph import Algorithm, ResourceGraph
+from rcspp.resource import (
+    AdditionExtensionFunction,
+    TrivialFeasibilityFunction,
+    ValueCostFunction,
+    ValueDominanceFunction,
+)
+
+
+# ── Shared helper ─────────────────────────────────────────────────────────────
+
+
+def _make_graph() -> ResourceGraph:
+    """Return a fresh 4-node graph with a single real resource (cost).
+
+    Topology::
+
+        0 ──(arc0,10)──▶ 1 ──(arc1,15)──▶ 3
+        │                                  ▲
+        └──(arc2,20)──▶ 2 ──(arc3, 5)─────┘
+
+    Both s-t paths (0→1→3 and 0→2→3) have base cost 25.
+    """
+    rg = ResourceGraph()
+    rg.add_real_resource(
+        AdditionExtensionFunction(),
+        TrivialFeasibilityFunction(),
+        ValueCostFunction(),
+        ValueDominanceFunction(),
+    )
+    rg.add_node(0, source=True)
+    rg.add_node(1)
+    rg.add_node(2)
+    rg.add_node(3, sink=True)
+    return rg
+
+
+# ── add_arc with dual_rows variants ──────────────────────────────────────────
+
+
+class TestAddArcDualRows:
+    """Test dual_rows normalisation in add_arc."""
+
+    def test_single_tuple(self):
+        """dual_rows as a single (index, coeff) tuple is normalised to one Row."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 2.5))
+
+        arc = rg.get_arc(arc_id)
+        assert len(arc.dual_rows) == 1
+        assert arc.dual_rows[0].index == 0
+        assert math.isclose(arc.dual_rows[0].coefficient, 2.5, abs_tol=1e-9)
+
+    def test_list_of_tuples(self):
+        """dual_rows as a list of tuples produces one Row per tuple."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((5.0,), 0, 3, cost=5.0, dual_rows=[(0, 1.5), (1, -0.5)])
+
+        arc = rg.get_arc(arc_id)
+        assert len(arc.dual_rows) == 2
+        assert arc.dual_rows[0].index == 0
+        assert math.isclose(arc.dual_rows[0].coefficient, 1.5, abs_tol=1e-9)
+        assert arc.dual_rows[1].index == 1
+        assert math.isclose(arc.dual_rows[1].coefficient, -0.5, abs_tol=1e-9)
+
+    def test_none_dual_rows(self):
+        """dual_rows=None (default) results in an empty row list."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0)
+
+        arc = rg.get_arc(arc_id)
+        assert len(arc.dual_rows) == 0
+
+    def test_empty_list_dual_rows(self):
+        """dual_rows=[] also results in an empty row list."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=[])
+
+        arc = rg.get_arc(arc_id)
+        assert len(arc.dual_rows) == 0
+
+
+# ── next_arc_id ───────────────────────────────────────────────────────────────
+
+
+class TestNextArcId:
+    """Test that next_arc_id() tracks arc additions correctly."""
+
+    def test_increments_with_add_arc(self):
+        """next_arc_id() increments by one after each add_arc call."""
+        rg = _make_graph()
+
+        assert rg._next_arc_id == 0
+        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
+        assert rg._next_arc_id == 1
+        arc1 = rg.add_arc((15.0,), 1, 3, cost=15.0)
+        assert rg._next_arc_id == 2
+
+        assert arc0 == 0
+        assert arc1 == 1
+
+    def test_cpp_next_arc_id_after_flush(self):
+        """C++ next_arc_id() matches Python _next_arc_id after flush."""
+        rg = _make_graph()
+        rg.add_arc((10.0,), 0, 1, cost=10.0)
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+
+        # Flush by calling get_arc
+        rg.get_arc(0)
+        assert rg._graph.next_arc_id() == rg._next_arc_id
+
+
+# ── add_rows_to_arc ───────────────────────────────────────────────────────────
+
+
+class TestAddRowsToArc:
+    """Test buffered row addition via add_rows_to_arc."""
+
+    def test_buffered_then_flushed(self):
+        """Rows added via add_rows_to_arc appear on the arc after flush."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0)
+
+        rg.add_rows_to_arc(arc_id, [(0, 3.0)])
+
+        arc = rg.get_arc(arc_id)  # triggers flush
+        assert len(arc.dual_rows) == 1
+        assert arc.dual_rows[0].index == 0
+        assert math.isclose(arc.dual_rows[0].coefficient, 3.0, abs_tol=1e-9)
+
+    def test_single_tuple_form(self):
+        """add_rows_to_arc accepts a single (index, coeff) tuple directly."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0)
+
+        rg.add_rows_to_arc(arc_id, (1, -1.0))
+
+        arc = rg.get_arc(arc_id)
+        assert len(arc.dual_rows) == 1
+        assert arc.dual_rows[0].index == 1
+        assert math.isclose(arc.dual_rows[0].coefficient, -1.0, abs_tol=1e-9)
+
+    def test_multiple_calls_accumulate(self):
+        """Multiple add_rows_to_arc calls accumulate rows on the same arc."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0)
+
+        rg.add_rows_to_arc(arc_id, [(0, 3.0)])
+        rg.add_rows_to_arc(arc_id, (1, -1.0))
+
+        arc = rg.get_arc(arc_id)
+        assert len(arc.dual_rows) == 2
+
+    def test_rows_appended_to_existing(self):
+        """Rows added via add_rows_to_arc are appended to rows already on the arc."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 1.0))
+        # First flush via get_arc to commit the arc with its initial row
+        arc = rg.get_arc(arc_id)
+        assert len(arc.dual_rows) == 1
+
+        rg.add_rows_to_arc(arc_id, [(1, 2.0)])
+        arc = rg.get_arc(arc_id)
+        assert len(arc.dual_rows) == 2
+        assert arc.dual_rows[0].index == 0
+        assert arc.dual_rows[1].index == 1
+
+    def test_arcs_buffered_before_rows(self):
+        """Rows may be buffered before the arc is flushed; flush order is arcs→rows."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((5.0,), 0, 3, cost=5.0)
+        # Arc is still in Python buffer; rows are buffered too.
+        rg.add_rows_to_arc(arc_id, [(0, 7.0)])
+
+        # solve() flushes in order: nodes→arcs→rows
+        sols = rg.solve()
+        assert len(sols) >= 1
+
+        arc = rg.get_arc(arc_id)
+        assert len(arc.dual_rows) == 1
+
+
+# ── add_rows ──────────────────────────────────────────────────────────────────
+
+
+class TestAddRows:
+    """Test bulk row addition via add_rows."""
+
+    def test_list_of_triples(self):
+        """add_rows with a list of (arc_id, index, coeff) triples."""
+        rg = _make_graph()
+        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
+        arc1 = rg.add_arc((5.0,), 1, 3, cost=5.0)
+
+        rg.add_rows([(arc0, 0, 1.0), (arc1, 0, 2.0)])
+
+        a0 = rg.get_arc(arc0)
+        a1 = rg.get_arc(arc1)
+        assert len(a0.dual_rows) == 1
+        assert math.isclose(a0.dual_rows[0].coefficient, 1.0, abs_tol=1e-9)
+        assert len(a1.dual_rows) == 1
+        assert math.isclose(a1.dual_rows[0].coefficient, 2.0, abs_tol=1e-9)
+
+    def test_numpy_2d_array(self):
+        """add_rows accepts a (N, 3) numpy float64 array."""
+        rg = _make_graph()
+        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
+        arc1 = rg.add_arc((15.0,), 1, 3, cost=15.0)
+
+        data = np.array([[arc0, 0, 1.5], [arc1, 1, 3.0]], dtype=np.float64)
+        rg.add_rows(data)
+
+        a0 = rg.get_arc(arc0)
+        a1 = rg.get_arc(arc1)
+        assert len(a0.dual_rows) == 1
+        assert math.isclose(a0.dual_rows[0].coefficient, 1.5, abs_tol=1e-9)
+        assert len(a1.dual_rows) == 1
+        assert arc1 == a1.id
+        assert math.isclose(a1.dual_rows[1 - 1].coefficient, 3.0, abs_tol=1e-9)
+
+    def test_multiple_rows_per_arc(self):
+        """Multiple rows for the same arc are all added correctly."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0)
+
+        rg.add_rows([(arc_id, 0, 1.0), (arc_id, 1, -2.0), (arc_id, 2, 0.5)])
+
+        arc = rg.get_arc(arc_id)
+        assert len(arc.dual_rows) == 3
+        coeffs = [r.coefficient for r in arc.dual_rows]
+        assert math.isclose(coeffs[0], 1.0, abs_tol=1e-9)
+        assert math.isclose(coeffs[1], -2.0, abs_tol=1e-9)
+        assert math.isclose(coeffs[2], 0.5, abs_tol=1e-9)
+
+
+# ── update_reduced_costs uses rows ────────────────────────────────────────────
+
+
+class TestUpdateReducedCosts:
+    """Test that update_reduced_costs correctly applies dual rows."""
+
+    def test_rows_shift_optimal_path(self):
+        """After update_reduced_costs, the path with negative reduced cost wins.
+
+        Base costs: 0→1→3 = 25, 0→2→3 = 25.
+        arc3 (2→3) has row (index=0, coeff=8.0).
+        duals = [1.0]  →  reduced cost of arc3 = 5.0 - 8.0*1.0 = -3.0.
+        0→2→3 reduced cost = 20 + (-3) = 17 < 25.
+        """
+        rg = _make_graph()
+        rg.add_arc((10.0,), 0, 1, cost=10.0)
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0, dual_rows=(0, 8.0))
+
+        rg.update_reduced_costs([1.0])
+
+        sols = rg.solve()
+        assert len(sols) >= 1
+        assert sols[0].path_node_ids == [0, 2, 3]
+        assert math.isclose(sols[0].cost, 17.0, abs_tol=1e-6)
+
+    def test_rows_added_after_arc_flush(self):
+        """Rows added via add_rows_to_arc after the arc is flushed are used."""
+        rg = _make_graph()
+        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
+        arc1 = rg.add_arc((15.0,), 1, 3, cost=15.0)
+        arc2 = rg.add_arc((20.0,), 0, 2, cost=20.0)
+        arc3 = rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        # Flush arcs first so they are in C++ before adding rows
+        rg.get_arc(arc3)
+
+        rg.add_rows_to_arc(arc3, [(0, 8.0)])
+        rg.update_reduced_costs([1.0])
+
+        sols = rg.solve()
+        assert len(sols) >= 1
+        assert sols[0].path_node_ids == [0, 2, 3]
+
+    def test_multiple_rows_sum(self):
+        """Reduced cost is base_cost - sum(coeff * dual) over all rows."""
+        rg = _make_graph()
+        rg.add_arc((10.0,), 0, 1, cost=10.0)
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        # arc3: base=5, rows: (0, 3.0) and (1, 2.0)
+        # duals=[1.0, 2.0] → reduced = 5 - 3*1 - 2*2 = 5 - 3 - 4 = -2
+        rg.add_arc((5.0,), 2, 3, cost=5.0, dual_rows=[(0, 3.0), (1, 2.0)])
+
+        rg.update_reduced_costs([1.0, 2.0])
+
+        sols = rg.solve()
+        assert len(sols) >= 1
+        assert sols[0].path_node_ids == [0, 2, 3]
+        assert math.isclose(sols[0].cost, 18.0, abs_tol=1e-6)  # 20 + (-2) = 18
+
+
+# ── clone ─────────────────────────────────────────────────────────────────────
+
+
+class TestClone:
+    """Test ResourceGraph.clone()."""
+
+    def test_clone_preserves_rows(self):
+        """clone() carries dual rows into the copy."""
+        rg = _make_graph()
+        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 2.0))
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        rg2 = rg.clone()
+
+        arc_clone = rg2.get_arc(arc0)
+        assert len(arc_clone.dual_rows) == 1
+        assert arc_clone.dual_rows[0].index == 0
+        assert math.isclose(arc_clone.dual_rows[0].coefficient, 2.0, abs_tol=1e-9)
+
+    def test_clone_same_optimal_cost(self):
+        """Solving the clone gives the same optimal cost as the original."""
+        rg = _make_graph()
+        rg.add_arc((10.0,), 0, 1, cost=10.0)
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        rg2 = rg.clone()
+
+        sols1 = rg.solve()
+        sols2 = rg2.solve()
+        assert len(sols1) >= 1 and len(sols2) >= 1
+        assert math.isclose(sols1[0].cost, sols2[0].cost, abs_tol=1e-6)
+
+    def test_clone_independent_remove_state(self):
+        """Removing an arc in the clone does not affect the original."""
+        rg = _make_graph()
+        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
+        arc1 = rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        rg2 = rg.clone()
+
+        # Remove arc in clone; original must still work
+        rg2.remove_arcs([arc0, arc1])
+        sols_orig = rg.solve()
+        assert len(sols_orig) >= 1
+        assert arc0 in [a.id for a in [rg.get_arc(arc0)]]
+
+    def test_clone_next_arc_id_matches(self):
+        """Python _next_arc_id on the clone mirrors the C++ next_arc_id()."""
+        rg = _make_graph()
+        rg.add_arc((10.0,), 0, 1, cost=10.0)
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+
+        rg2 = rg.clone()
+
+        assert rg2._next_arc_id == rg._next_arc_id
+        assert rg2._next_arc_id == rg2._graph.next_arc_id()
+
+    def test_clone_stable_arc_ids(self):
+        """Arc IDs in the clone are identical to those in the original."""
+        rg = _make_graph()
+        a0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
+        a1 = rg.add_arc((15.0,), 1, 3, cost=15.0)
+        a2 = rg.add_arc((20.0,), 0, 2, cost=20.0)
+        a3 = rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        rg2 = rg.clone()
+
+        for arc_id in [a0, a1, a2, a3]:
+            arc_orig = rg.get_arc(arc_id)
+            arc_clone = rg2.get_arc(arc_id)
+            assert arc_orig.id == arc_clone.id
+            assert math.isclose(arc_orig.cost, arc_clone.cost, abs_tol=1e-9)
+
+    def test_clone_independent_reduced_costs(self):
+        """update_reduced_costs on the clone does not affect the original."""
+        rg = _make_graph()
+        rg.add_arc((10.0,), 0, 1, cost=10.0)
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0, dual_rows=(0, 8.0))
+
+        rg2 = rg.clone()
+
+        # Update clone only; original costs should be unchanged
+        rg2.update_reduced_costs([1.0])
+
+        sols_orig = rg.solve()
+        sols_clone = rg2.solve()
+
+        # Original: both paths cost 25 (no update)
+        assert math.isclose(sols_orig[0].cost, 25.0, abs_tol=1e-6)
+        # Clone: 0→2→3 wins at cost 17
+        assert sols_clone[0].path_node_ids == [0, 2, 3]
+        assert math.isclose(sols_clone[0].cost, 17.0, abs_tol=1e-6)
+
+
+# ── clone_topology ────────────────────────────────────────────────────────────
+
+
+class TestCloneTopology:
+    """Test ResourceGraph.clone_topology() — clone with no dual rows."""
+
+    def test_rows_stripped(self):
+        """clone_topology() produces arcs with empty dual_rows."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=[(0, 1.0), (1, 2.0)])
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        rg2 = rg.clone_topology()
+
+        arc_clone = rg2.get_arc(arc_id)
+        assert len(arc_clone.dual_rows) == 0
+
+    def test_original_rows_preserved(self):
+        """After clone_topology(), the original graph still has its rows."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 1.0))
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.clone_topology()
+
+        arc_orig = rg.get_arc(arc_id)
+        assert len(arc_orig.dual_rows) == 1
+
+    def test_add_rows_to_topology_clone(self):
+        """Rows can be added to a topology clone independently of the original."""
+        rg = _make_graph()
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 1.0))
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        rg2 = rg.clone_topology()
+        rg2.add_rows_to_arc(arc_id, [(0, 5.0)])
+
+        arc_clone = rg2.get_arc(arc_id)
+        assert len(arc_clone.dual_rows) == 1
+        assert math.isclose(arc_clone.dual_rows[0].coefficient, 5.0, abs_tol=1e-9)
+
+        # Original is untouched
+        arc_orig = rg.get_arc(arc_id)
+        assert len(arc_orig.dual_rows) == 1
+        assert math.isclose(arc_orig.dual_rows[0].coefficient, 1.0, abs_tol=1e-9)
+
+    def test_topology_clone_solves_correctly(self):
+        """A topology clone without rows solves like a clean graph."""
+        rg = _make_graph()
+        rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 99.0))
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        rg2 = rg.clone_topology()
+        # No duals applied — arc costs remain at their base values
+        sols = rg2.solve()
+        assert len(sols) >= 1
+        assert math.isclose(sols[0].cost, 25.0, abs_tol=1e-6)
+
+
+# ── clone_removed_arcs ────────────────────────────────────────────────────────
+
+
+class TestCloneRemovedArcs:
+    """Test clone(clone_removed_arcs=True)."""
+
+    def test_removed_arc_present_in_clone_after_restore(self):
+        """A removed arc cloned with clone_removed_arcs=True can be restored."""
+        rg = _make_graph()
+        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
+        arc1 = rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        rg.remove_arcs([arc0, arc1])
+
+        rg2 = rg.clone(clone_removed_arcs=True)
+        rg2.restore_arcs([arc0, arc1])
+
+        sols = rg2.solve()
+        assert len(sols) >= 1
+
+    def test_removed_arc_absent_without_flag(self):
+        """clone(clone_removed_arcs=False) drops removed arcs; restoring them is a no-op.
+
+        restore_arcs silently skips IDs that are not in the removed set, so the
+        only reliable check is that the clone solves as if those arcs are gone.
+        """
+        rg = _make_graph()
+        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
+        arc1 = rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        rg.remove_arcs([arc0, arc1])
+
+        rg2 = rg.clone()  # clone_removed_arcs=False by default
+
+        # Attempting to restore non-existent arcs is silently ignored
+        rg2.restore_arcs([arc0, arc1])
+
+        # Only 0→2→3 is reachable in the clone (arc0/arc1 used the 0→1→3 path)
+        sols = rg2.solve()
+        assert len(sols) >= 1
+        # Node 1 is only reachable via arc0 (0→1); if arc0 is gone it can't appear
+        assert all(1 not in s.path_node_ids for s in sols), (
+            "Node 1 should be unreachable when arc0 (0→1) is absent from the clone"
+        )
+        assert sols[0].path_node_ids == [0, 2, 3]
+
+    def test_independent_restore(self):
+        """Restoring an arc in the clone does not affect the original."""
+        rg = _make_graph()
+        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
+        arc1 = rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((5.0,), 2, 3, cost=5.0)
+
+        rg.remove_arcs([arc0, arc1])
+        rg2 = rg.clone(clone_removed_arcs=True)
+        rg2.restore_arcs([arc0, arc1])
+
+        # Original still has arc0 removed; only 0→2→3 is available
+        sols_orig = rg.solve()
+        sols_clone = rg2.solve()
+
+        assert sols_orig[0].path_node_ids == [0, 2, 3]
+        # Clone has both paths; optimal is the same cost from either
+        assert len(sols_clone) >= 1
+
+
+# ── Run directly ──────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])

--- a/src/python/test_clone.py
+++ b/src/python/test_clone.py
@@ -1,10 +1,9 @@
 #  Copyright (c) 2025 Laboratory for Combinatorial Optimization in Real-time Environment.
 #  All rights reserved.
-
 """Tests for ResourceGraph.clone, clone_topology, add_rows_to_arc, and add_rows.
 
 Covers:
-- add_arc with dual_rows as a single tuple (index, coeff) or list of tuples
+- add_arc with rows as a single tuple (index, coeff) or list of tuples
 - next_arc_id() returns the expected next arc ID
 - add_rows_to_arc buffers rows and flushes them correctly
 - add_rows adds rows in bulk from a list of triples or a 2-D numpy array
@@ -20,17 +19,17 @@ import os
 import sys
 
 import numpy as np
+
 relative_path = "../python_interface/"
 sys.path.insert(0, os.path.abspath(relative_path))
 
-from rcspp.graph import Algorithm, ResourceGraph
-from rcspp.resource import (
+from rcspp.graph import ResourceGraph  # noqa: E402
+from rcspp.resource import (  # noqa: E402
     AdditionExtensionFunction,
     TrivialFeasibilityFunction,
     ValueCostFunction,
     ValueDominanceFunction,
 )
-
 
 # ── Shared helper ─────────────────────────────────────────────────────────────
 
@@ -60,49 +59,49 @@ def _make_graph() -> ResourceGraph:
     return rg
 
 
-# ── add_arc with dual_rows variants ──────────────────────────────────────────
+# ── add_arc with rows variants ──────────────────────────────────────────
 
 
 class TestAddArcDualRows:
-    """Test dual_rows normalisation in add_arc."""
+    """Test rows normalisation in add_arc."""
 
     def test_single_tuple(self):
-        """dual_rows as a single (index, coeff) tuple is normalised to one Row."""
+        """Rows as a single (index, coeff) tuple is normalised to one Row."""
         rg = _make_graph()
-        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 2.5))
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, rows=(0, 2.5))
 
         arc = rg.get_arc(arc_id)
-        assert len(arc.dual_rows) == 1
-        assert arc.dual_rows[0].index == 0
-        assert math.isclose(arc.dual_rows[0].coefficient, 2.5, abs_tol=1e-9)
+        assert len(arc.rows) == 1
+        assert arc.rows[0].index == 0
+        assert math.isclose(arc.rows[0].coefficient, 2.5, abs_tol=1e-9)
 
     def test_list_of_tuples(self):
-        """dual_rows as a list of tuples produces one Row per tuple."""
+        """Rows as a list of tuples produces one Row per tuple."""
         rg = _make_graph()
-        arc_id = rg.add_arc((5.0,), 0, 3, cost=5.0, dual_rows=[(0, 1.5), (1, -0.5)])
+        arc_id = rg.add_arc((5.0,), 0, 3, cost=5.0, rows=[(0, 1.5), (1, -0.5)])
 
         arc = rg.get_arc(arc_id)
-        assert len(arc.dual_rows) == 2
-        assert arc.dual_rows[0].index == 0
-        assert math.isclose(arc.dual_rows[0].coefficient, 1.5, abs_tol=1e-9)
-        assert arc.dual_rows[1].index == 1
-        assert math.isclose(arc.dual_rows[1].coefficient, -0.5, abs_tol=1e-9)
+        assert len(arc.rows) == 2
+        assert arc.rows[0].index == 0
+        assert math.isclose(arc.rows[0].coefficient, 1.5, abs_tol=1e-9)
+        assert arc.rows[1].index == 1
+        assert math.isclose(arc.rows[1].coefficient, -0.5, abs_tol=1e-9)
 
-    def test_none_dual_rows(self):
-        """dual_rows=None (default) results in an empty row list."""
+    def test_none_rows(self):
+        """Rows=None (default) results in an empty row list."""
         rg = _make_graph()
         arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0)
 
         arc = rg.get_arc(arc_id)
-        assert len(arc.dual_rows) == 0
+        assert len(arc.rows) == 0
 
-    def test_empty_list_dual_rows(self):
-        """dual_rows=[] also results in an empty row list."""
+    def test_empty_list_rows(self):
+        """Rows=[] also results in an empty row list."""
         rg = _make_graph()
-        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=[])
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, rows=[])
 
         arc = rg.get_arc(arc_id)
-        assert len(arc.dual_rows) == 0
+        assert len(arc.rows) == 0
 
 
 # ── next_arc_id ───────────────────────────────────────────────────────────────
@@ -149,9 +148,9 @@ class TestAddRowsToArc:
         rg.add_rows_to_arc(arc_id, [(0, 3.0)])
 
         arc = rg.get_arc(arc_id)  # triggers flush
-        assert len(arc.dual_rows) == 1
-        assert arc.dual_rows[0].index == 0
-        assert math.isclose(arc.dual_rows[0].coefficient, 3.0, abs_tol=1e-9)
+        assert len(arc.rows) == 1
+        assert arc.rows[0].index == 0
+        assert math.isclose(arc.rows[0].coefficient, 3.0, abs_tol=1e-9)
 
     def test_single_tuple_form(self):
         """add_rows_to_arc accepts a single (index, coeff) tuple directly."""
@@ -161,9 +160,9 @@ class TestAddRowsToArc:
         rg.add_rows_to_arc(arc_id, (1, -1.0))
 
         arc = rg.get_arc(arc_id)
-        assert len(arc.dual_rows) == 1
-        assert arc.dual_rows[0].index == 1
-        assert math.isclose(arc.dual_rows[0].coefficient, -1.0, abs_tol=1e-9)
+        assert len(arc.rows) == 1
+        assert arc.rows[0].index == 1
+        assert math.isclose(arc.rows[0].coefficient, -1.0, abs_tol=1e-9)
 
     def test_multiple_calls_accumulate(self):
         """Multiple add_rows_to_arc calls accumulate rows on the same arc."""
@@ -174,21 +173,21 @@ class TestAddRowsToArc:
         rg.add_rows_to_arc(arc_id, (1, -1.0))
 
         arc = rg.get_arc(arc_id)
-        assert len(arc.dual_rows) == 2
+        assert len(arc.rows) == 2
 
     def test_rows_appended_to_existing(self):
         """Rows added via add_rows_to_arc are appended to rows already on the arc."""
         rg = _make_graph()
-        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 1.0))
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, rows=(0, 1.0))
         # First flush via get_arc to commit the arc with its initial row
         arc = rg.get_arc(arc_id)
-        assert len(arc.dual_rows) == 1
+        assert len(arc.rows) == 1
 
         rg.add_rows_to_arc(arc_id, [(1, 2.0)])
         arc = rg.get_arc(arc_id)
-        assert len(arc.dual_rows) == 2
-        assert arc.dual_rows[0].index == 0
-        assert arc.dual_rows[1].index == 1
+        assert len(arc.rows) == 2
+        assert arc.rows[0].index == 0
+        assert arc.rows[1].index == 1
 
     def test_arcs_buffered_before_rows(self):
         """Rows may be buffered before the arc is flushed; flush order is arcs→rows."""
@@ -202,7 +201,7 @@ class TestAddRowsToArc:
         assert len(sols) >= 1
 
         arc = rg.get_arc(arc_id)
-        assert len(arc.dual_rows) == 1
+        assert len(arc.rows) == 1
 
 
 # ── add_rows ──────────────────────────────────────────────────────────────────
@@ -221,10 +220,10 @@ class TestAddRows:
 
         a0 = rg.get_arc(arc0)
         a1 = rg.get_arc(arc1)
-        assert len(a0.dual_rows) == 1
-        assert math.isclose(a0.dual_rows[0].coefficient, 1.0, abs_tol=1e-9)
-        assert len(a1.dual_rows) == 1
-        assert math.isclose(a1.dual_rows[0].coefficient, 2.0, abs_tol=1e-9)
+        assert len(a0.rows) == 1
+        assert math.isclose(a0.rows[0].coefficient, 1.0, abs_tol=1e-9)
+        assert len(a1.rows) == 1
+        assert math.isclose(a1.rows[0].coefficient, 2.0, abs_tol=1e-9)
 
     def test_numpy_2d_array(self):
         """add_rows accepts a (N, 3) numpy float64 array."""
@@ -237,11 +236,11 @@ class TestAddRows:
 
         a0 = rg.get_arc(arc0)
         a1 = rg.get_arc(arc1)
-        assert len(a0.dual_rows) == 1
-        assert math.isclose(a0.dual_rows[0].coefficient, 1.5, abs_tol=1e-9)
-        assert len(a1.dual_rows) == 1
+        assert len(a0.rows) == 1
+        assert math.isclose(a0.rows[0].coefficient, 1.5, abs_tol=1e-9)
+        assert len(a1.rows) == 1
         assert arc1 == a1.id
-        assert math.isclose(a1.dual_rows[1 - 1].coefficient, 3.0, abs_tol=1e-9)
+        assert math.isclose(a1.rows[1 - 1].coefficient, 3.0, abs_tol=1e-9)
 
     def test_multiple_rows_per_arc(self):
         """Multiple rows for the same arc are all added correctly."""
@@ -251,8 +250,8 @@ class TestAddRows:
         rg.add_rows([(arc_id, 0, 1.0), (arc_id, 1, -2.0), (arc_id, 2, 0.5)])
 
         arc = rg.get_arc(arc_id)
-        assert len(arc.dual_rows) == 3
-        coeffs = [r.coefficient for r in arc.dual_rows]
+        assert len(arc.rows) == 3
+        coeffs = [r.coefficient for r in arc.rows]
         assert math.isclose(coeffs[0], 1.0, abs_tol=1e-9)
         assert math.isclose(coeffs[1], -2.0, abs_tol=1e-9)
         assert math.isclose(coeffs[2], 0.5, abs_tol=1e-9)
@@ -276,7 +275,7 @@ class TestUpdateReducedCosts:
         rg.add_arc((10.0,), 0, 1, cost=10.0)
         rg.add_arc((15.0,), 1, 3, cost=15.0)
         rg.add_arc((20.0,), 0, 2, cost=20.0)
-        rg.add_arc((5.0,), 2, 3, cost=5.0, dual_rows=(0, 8.0))
+        rg.add_arc((5.0,), 2, 3, cost=5.0, rows=(0, 8.0))
 
         rg.update_reduced_costs([1.0])
 
@@ -288,9 +287,9 @@ class TestUpdateReducedCosts:
     def test_rows_added_after_arc_flush(self):
         """Rows added via add_rows_to_arc after the arc is flushed are used."""
         rg = _make_graph()
-        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
-        arc1 = rg.add_arc((15.0,), 1, 3, cost=15.0)
-        arc2 = rg.add_arc((20.0,), 0, 2, cost=20.0)
+        rg.add_arc((10.0,), 0, 1, cost=10.0)
+        rg.add_arc((15.0,), 1, 3, cost=15.0)
+        rg.add_arc((20.0,), 0, 2, cost=20.0)
         arc3 = rg.add_arc((5.0,), 2, 3, cost=5.0)
 
         # Flush arcs first so they are in C++ before adding rows
@@ -311,7 +310,7 @@ class TestUpdateReducedCosts:
         rg.add_arc((20.0,), 0, 2, cost=20.0)
         # arc3: base=5, rows: (0, 3.0) and (1, 2.0)
         # duals=[1.0, 2.0] → reduced = 5 - 3*1 - 2*2 = 5 - 3 - 4 = -2
-        rg.add_arc((5.0,), 2, 3, cost=5.0, dual_rows=[(0, 3.0), (1, 2.0)])
+        rg.add_arc((5.0,), 2, 3, cost=5.0, rows=[(0, 3.0), (1, 2.0)])
 
         rg.update_reduced_costs([1.0, 2.0])
 
@@ -328,9 +327,9 @@ class TestClone:
     """Test ResourceGraph.clone()."""
 
     def test_clone_preserves_rows(self):
-        """clone() carries dual rows into the copy."""
+        """Clone() carries dual rows into the copy."""
         rg = _make_graph()
-        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 2.0))
+        arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0, rows=(0, 2.0))
         rg.add_arc((15.0,), 1, 3, cost=15.0)
         rg.add_arc((20.0,), 0, 2, cost=20.0)
         rg.add_arc((5.0,), 2, 3, cost=5.0)
@@ -338,9 +337,9 @@ class TestClone:
         rg2 = rg.clone()
 
         arc_clone = rg2.get_arc(arc0)
-        assert len(arc_clone.dual_rows) == 1
-        assert arc_clone.dual_rows[0].index == 0
-        assert math.isclose(arc_clone.dual_rows[0].coefficient, 2.0, abs_tol=1e-9)
+        assert len(arc_clone.rows) == 1
+        assert arc_clone.rows[0].index == 0
+        assert math.isclose(arc_clone.rows[0].coefficient, 2.0, abs_tol=1e-9)
 
     def test_clone_same_optimal_cost(self):
         """Solving the clone gives the same optimal cost as the original."""
@@ -406,7 +405,7 @@ class TestClone:
         rg.add_arc((10.0,), 0, 1, cost=10.0)
         rg.add_arc((15.0,), 1, 3, cost=15.0)
         rg.add_arc((20.0,), 0, 2, cost=20.0)
-        rg.add_arc((5.0,), 2, 3, cost=5.0, dual_rows=(0, 8.0))
+        rg.add_arc((5.0,), 2, 3, cost=5.0, rows=(0, 8.0))
 
         rg2 = rg.clone()
 
@@ -430,9 +429,9 @@ class TestCloneTopology:
     """Test ResourceGraph.clone_topology() — clone with no dual rows."""
 
     def test_rows_stripped(self):
-        """clone_topology() produces arcs with empty dual_rows."""
+        """clone_topology() produces arcs with empty rows."""
         rg = _make_graph()
-        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=[(0, 1.0), (1, 2.0)])
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, rows=[(0, 1.0), (1, 2.0)])
         rg.add_arc((15.0,), 1, 3, cost=15.0)
         rg.add_arc((20.0,), 0, 2, cost=20.0)
         rg.add_arc((5.0,), 2, 3, cost=5.0)
@@ -440,22 +439,22 @@ class TestCloneTopology:
         rg2 = rg.clone_topology()
 
         arc_clone = rg2.get_arc(arc_id)
-        assert len(arc_clone.dual_rows) == 0
+        assert len(arc_clone.rows) == 0
 
     def test_original_rows_preserved(self):
         """After clone_topology(), the original graph still has its rows."""
         rg = _make_graph()
-        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 1.0))
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, rows=(0, 1.0))
         rg.add_arc((15.0,), 1, 3, cost=15.0)
         rg.clone_topology()
 
         arc_orig = rg.get_arc(arc_id)
-        assert len(arc_orig.dual_rows) == 1
+        assert len(arc_orig.rows) == 1
 
     def test_add_rows_to_topology_clone(self):
         """Rows can be added to a topology clone independently of the original."""
         rg = _make_graph()
-        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 1.0))
+        arc_id = rg.add_arc((10.0,), 0, 1, cost=10.0, rows=(0, 1.0))
         rg.add_arc((15.0,), 1, 3, cost=15.0)
         rg.add_arc((20.0,), 0, 2, cost=20.0)
         rg.add_arc((5.0,), 2, 3, cost=5.0)
@@ -464,18 +463,18 @@ class TestCloneTopology:
         rg2.add_rows_to_arc(arc_id, [(0, 5.0)])
 
         arc_clone = rg2.get_arc(arc_id)
-        assert len(arc_clone.dual_rows) == 1
-        assert math.isclose(arc_clone.dual_rows[0].coefficient, 5.0, abs_tol=1e-9)
+        assert len(arc_clone.rows) == 1
+        assert math.isclose(arc_clone.rows[0].coefficient, 5.0, abs_tol=1e-9)
 
         # Original is untouched
         arc_orig = rg.get_arc(arc_id)
-        assert len(arc_orig.dual_rows) == 1
-        assert math.isclose(arc_orig.dual_rows[0].coefficient, 1.0, abs_tol=1e-9)
+        assert len(arc_orig.rows) == 1
+        assert math.isclose(arc_orig.rows[0].coefficient, 1.0, abs_tol=1e-9)
 
     def test_topology_clone_solves_correctly(self):
         """A topology clone without rows solves like a clean graph."""
         rg = _make_graph()
-        rg.add_arc((10.0,), 0, 1, cost=10.0, dual_rows=(0, 99.0))
+        rg.add_arc((10.0,), 0, 1, cost=10.0, rows=(0, 99.0))
         rg.add_arc((15.0,), 1, 3, cost=15.0)
         rg.add_arc((20.0,), 0, 2, cost=20.0)
         rg.add_arc((5.0,), 2, 3, cost=5.0)
@@ -510,10 +509,11 @@ class TestCloneRemovedArcs:
         assert len(sols) >= 1
 
     def test_removed_arc_absent_without_flag(self):
-        """clone(clone_removed_arcs=False) drops removed arcs; restoring them is a no-op.
+        """clone(clone_removed_arcs=False) drops removed arcs; restoring them is a no-
+        op.
 
-        restore_arcs silently skips IDs that are not in the removed set, so the
-        only reliable check is that the clone solves as if those arcs are gone.
+        restore_arcs silently skips IDs that are not in the removed set, so the only
+        reliable check is that the clone solves as if those arcs are gone.
         """
         rg = _make_graph()
         arc0 = rg.add_arc((10.0,), 0, 1, cost=10.0)
@@ -532,9 +532,9 @@ class TestCloneRemovedArcs:
         sols = rg2.solve()
         assert len(sols) >= 1
         # Node 1 is only reachable via arc0 (0→1); if arc0 is gone it can't appear
-        assert all(1 not in s.path_node_ids for s in sols), (
-            "Node 1 should be unreachable when arc0 (0→1) is absent from the clone"
-        )
+        assert all(
+            1 not in s.path_node_ids for s in sols
+        ), "Node 1 should be unreachable when arc0 (0→1) is absent from the clone"
         assert sols[0].path_node_ids == [0, 2, 3]
 
     def test_independent_restore(self):

--- a/src/python/test_graph.py
+++ b/src/python/test_graph.py
@@ -178,11 +178,11 @@ def test_force_arc_solve_uses_forced_path():
 # ── update_reduced_costs numpy tests ──────────────────────────────────────────
 
 
-def _make_rg_with_dual_rows():
+def _make_rg_with_rows():
     """2-arc graph where arc costs are set via dual rows.
 
-    Arc 0 (0→1): base cost=10, dual_row index=0 coef=1  → reduced = 10 - duals[0]
-    Arc 1 (1→2): base cost=20, dual_row index=1 coef=2  → reduced = 20 - 2*duals[1]
+    Arc 0 (0→1): base cost=10, row index=0 coef=1  → reduced = 10 - duals[0]
+    Arc 1 (1→2): base cost=20, row index=1 coef=2  → reduced = 20 - 2*duals[1]
     """
     from rcspp.graph import Row
 
@@ -196,15 +196,15 @@ def _make_rg_with_dual_rows():
     rg.add_node(0, source=True)
     rg.add_node(1)
     rg.add_node(2, sink=True)
-    rg.add_arc(1.0, 0, 1, cost=10.0, dual_rows=[Row(0, 1.0)])
-    rg.add_arc(1.0, 1, 2, cost=20.0, dual_rows=[Row(1, 2.0)])
+    rg.add_arc(1.0, 0, 1, cost=10.0, rows=[Row(0, 1.0)])
+    rg.add_arc(1.0, 1, 2, cost=20.0, rows=[Row(1, 2.0)])
     rg.update()
     return rg
 
 
 def test_update_reduced_costs_numpy_1d():
     """update_reduced_costs accepts a 1-D numpy array and applies it correctly."""
-    rg = _make_rg_with_dual_rows()
+    rg = _make_rg_with_rows()
     duals = np.array([3.0, 4.0])  # reduced: arc0 = 10-3=7, arc1 = 20-8=12
 
     rg.update_reduced_costs(duals)
@@ -300,8 +300,8 @@ def test_remove_restore_arcs_roundtrip():
 
 def test_update_reduced_costs_numpy_matches_list():
     """Numpy array and plain list produce identical reduced costs."""
-    rg_np = _make_rg_with_dual_rows()
-    rg_list = _make_rg_with_dual_rows()
+    rg_np = _make_rg_with_rows()
+    rg_list = _make_rg_with_rows()
     duals_list = [5.0, 3.0]
     duals_np = np.array(duals_list)
 

--- a/src/python/test_graph.py
+++ b/src/python/test_graph.py
@@ -45,9 +45,9 @@ def make_diamond():
     rg.add_node(0, source=True)
     rg.add_node(1)
     rg.add_node(2, sink=True)
-    rg.add_arc(1.0, 0, 1, cost=1.0, arc_id=0)
-    rg.add_arc(5.0, 0, 2, cost=5.0, arc_id=1)
-    rg.add_arc(3.0, 1, 2, cost=3.0, arc_id=2)
+    rg.add_arc(1.0, 0, 1, cost=1.0)
+    rg.add_arc(5.0, 0, 2, cost=5.0)
+    rg.add_arc(3.0, 1, 2, cost=3.0)
     rg.update()
     return rg
 
@@ -123,7 +123,7 @@ def test_force_arc_already_unique():
     rg = make_resource_graph()
     rg.add_node(0, source=True)
     rg.add_node(1, sink=True)
-    rg.add_arc(1.0, 0, 1, cost=1.0, arc_id=0)
+    rg.add_arc(1.0, 0, 1, cost=1.0)
     rg.update()
 
     removed = rg.force_arc(0)
@@ -139,8 +139,8 @@ def test_force_arc_parallel_arcs_dedup():
     rg = make_resource_graph()
     rg.add_node(0, source=True)
     rg.add_node(1, sink=True)
-    rg.add_arc(1.0, 0, 1, cost=1.0, arc_id=0)
-    rg.add_arc(2.0, 0, 1, cost=2.0, arc_id=1)
+    rg.add_arc(1.0, 0, 1, cost=1.0)
+    rg.add_arc(2.0, 0, 1, cost=2.0)
     rg.update()
 
     removed = rg.force_arc(0)
@@ -196,8 +196,8 @@ def _make_rg_with_dual_rows():
     rg.add_node(0, source=True)
     rg.add_node(1)
     rg.add_node(2, sink=True)
-    rg.add_arc(1.0, 0, 1, cost=10.0, dual_rows=[Row(0, 1.0)], arc_id=0)
-    rg.add_arc(1.0, 1, 2, cost=20.0, dual_rows=[Row(1, 2.0)], arc_id=1)
+    rg.add_arc(1.0, 0, 1, cost=10.0, dual_rows=[Row(0, 1.0)])
+    rg.add_arc(1.0, 1, 2, cost=20.0, dual_rows=[Row(1, 2.0)])
     rg.update()
     return rg
 
@@ -313,3 +313,80 @@ def test_update_reduced_costs_numpy_matches_list():
 
     assert len(sols_np) >= 1 and len(sols_list) >= 1
     assert math.isclose(sols_np[0].cost, sols_list[0].cost, abs_tol=1e-9)
+
+
+# ── add_arc predicted-id tests ────────────────────────────────────────────────
+
+
+def test_add_arc_returns_sequential_ids():
+    """add_arc returns 0, 1, 2, … in insertion order."""
+    rg = make_resource_graph()
+    rg.add_node(0, source=True)
+    rg.add_node(1)
+    rg.add_node(2, sink=True)
+
+    id0 = rg.add_arc(1.0, 0, 1, cost=1.0)
+    id1 = rg.add_arc(5.0, 0, 2, cost=5.0)
+    id2 = rg.add_arc(3.0, 1, 2, cost=3.0)
+
+    assert id0 == 0
+    assert id1 == 1
+    assert id2 == 2
+
+
+def test_add_arc_predicted_id_matches_get_arc():
+    """The id returned by add_arc is the id under which the arc is stored after
+    flush."""
+    rg = make_resource_graph()
+    rg.add_node(0, source=True)
+    rg.add_node(1, sink=True)
+
+    arc_id = rg.add_arc(2.5, 0, 1, cost=2.5)
+    rg.update()
+
+    arc = rg.get_arc(arc_id)
+    assert arc is not None
+    assert arc.id == arc_id
+    assert math.isclose(arc.cost, 2.5)
+
+
+def test_add_arc_ids_continue_across_flushes():
+    """IDs are monotonically increasing even when arcs are flushed in batches."""
+    rg = make_resource_graph()
+    rg.add_node(0, source=True)
+    rg.add_node(1)
+    rg.add_node(2, sink=True)
+
+    id0 = rg.add_arc(1.0, 0, 1, cost=1.0)
+    rg.update()  # flush first arc
+
+    id1 = rg.add_arc(2.0, 1, 2, cost=2.0)
+    rg.update()  # flush second arc
+
+    assert id0 == 0
+    assert id1 == 1
+    assert rg.get_arc(id0) is not None
+    assert rg.get_arc(id1) is not None
+
+
+def test_add_arc_id_survives_remove_restore():
+    """IDs continue incrementing after a remove/restore cycle; the slot is reused."""
+    rg = make_resource_graph()
+    rg.add_node(0, source=True)
+    rg.add_node(1)
+    rg.add_node(2, sink=True)
+
+    id0 = rg.add_arc(1.0, 0, 1, cost=1.0)
+    id1 = rg.add_arc(5.0, 0, 2, cost=5.0)
+    rg.update()
+
+    rg.remove_arc(id0)
+    rg.restore_arc(id0)
+
+    id2 = rg.add_arc(3.0, 1, 2, cost=3.0)
+    rg.update()
+
+    assert id2 == 2  # next id after 0 and 1
+    assert rg.get_arc(id0) is not None
+    assert rg.get_arc(id1) is not None
+    assert rg.get_arc(id2) is not None

--- a/src/python/vrp/vrp.py
+++ b/src/python/vrp/vrp.py
@@ -123,19 +123,19 @@ class VRP:
         # Depot→depot arc: assign an infinite base cost so it is never used.
         if orig.depot and dest.depot:
             base_cost = math.inf
-            dual_rows: list[Row] = []
+            rows: list[Row] = []
         else:
             base_cost = distance
             # Non-depot origin: store the dual coefficient so update_reduced_costs
             # can compute  reduced_cost = distance - π_{orig_id}  without rebuilding.
-            dual_rows = [] if orig.depot else [Row(orig_id, 1.0)]
+            rows = [] if orig.depot else [Row(orig_id, 1.0)]
 
         resource_graph.add_arc(
             (base_cost, travel_time, demand),
             orig_id,
             dest_id,
             base_cost,
-            dual_rows,
+            rows,
         )
 
     # ── Utility ───────────────────────────────────────────────────────────────

--- a/src/python_interface/rcspp/graph.cpp
+++ b/src/python_interface/rcspp/graph.cpp
@@ -147,7 +147,7 @@ void init_graph(py::module_& m) {
                  py::arg("origin_id"),
                  py::arg("destination_id"),
                  py::arg("cost") = 0.0,
-                 py::arg("dual_rows") = std::vector<Row>{},
+                 py::arg("rows") = std::vector<Row>{},
                  py::return_value_policy::reference);
     }
 
@@ -175,7 +175,7 @@ void init_graph(py::module_& m) {
             py::return_value_policy::reference)
         .def_readwrite("extender", &Arc<RealRC>::extender)
         .def_readwrite("cost", &Arc<RealRC>::cost)
-        .def_readwrite("dual_rows", &Arc<RealRC>::dual_rows)
+        .def_readwrite("rows", &Arc<RealRC>::rows)
         .def("__str__", &Arc<RealRC>::to_string)
         .def("__repr__", &Arc<RealRC>::to_string);
 

--- a/src/python_interface/rcspp/graph.cpp
+++ b/src/python_interface/rcspp/graph.cpp
@@ -146,10 +146,8 @@ void init_graph(py::module_& m) {
                 auto rip = ridx.mutable_unchecked<1>();
                 auto rcp = rcoeff.mutable_unchecked<1>();
                 for (size_t i = 0; i < nr; ++i) {
-                    rip(static_cast<py::ssize_t>(i)) =
-                        static_cast<int64_t>(rows[i].index);
-                    rcp(static_cast<py::ssize_t>(i)) =
-                        static_cast<double>(rows[i].coefficient);
+                    rip(static_cast<py::ssize_t>(i)) = static_cast<int64_t>(rows[i].index);
+                    rcp(static_cast<py::ssize_t>(i)) = static_cast<double>(rows[i].coefficient);
                 }
                 return py::make_tuple(sol.cost, nodes, ridx, rcoeff);
             },

--- a/src/python_interface/rcspp/graph.cpp
+++ b/src/python_interface/rcspp/graph.cpp
@@ -126,7 +126,35 @@ void init_graph(py::module_& m) {
         .def_readwrite("cost", &Solution::cost)
         .def_readwrite("path_node_ids", &Solution::path_node_ids)
         .def_readwrite("path_arc_ids", &Solution::path_arc_ids)
-        .def_readwrite("column", &Solution::column);
+        .def_readwrite("column", &Solution::column)
+        .def(
+            "to_arrays",
+            [](const Solution& sol) -> py::tuple {
+                // nodes: int64 array
+                const auto& nids = sol.path_node_ids;
+                auto nodes = py::array_t<int64_t>(static_cast<py::ssize_t>(nids.size()));
+                auto nptr = nodes.mutable_unchecked<1>();
+                py::ssize_t k = 0;
+                for (size_t n : nids) {
+                    nptr(k++) = static_cast<int64_t>(n);
+                }
+                // rows: separate int64 (index) and float64 (coefficient) arrays
+                const auto& rows = sol.column.rows;
+                size_t nr = rows.size();
+                auto ridx = py::array_t<int64_t>(static_cast<py::ssize_t>(nr));
+                auto rcoeff = py::array_t<double>(static_cast<py::ssize_t>(nr));
+                auto rip = ridx.mutable_unchecked<1>();
+                auto rcp = rcoeff.mutable_unchecked<1>();
+                for (size_t i = 0; i < nr; ++i) {
+                    rip(static_cast<py::ssize_t>(i)) =
+                        static_cast<int64_t>(rows[i].index);
+                    rcp(static_cast<py::ssize_t>(i)) =
+                        static_cast<double>(rows[i].coefficient);
+                }
+                return py::make_tuple(sol.cost, nodes, ridx, rcoeff);
+            },
+            "Return (cost, node_ids, row_indices, row_coefficients) as numpy arrays. "
+            "Avoids per-Row Python object overhead during column extraction.");
 
     // ══════════════════════════════════════════════════════════════════════════
     // RealResource — primary bindings with full Node/Arc/Graph public exposure

--- a/src/python_interface/rcspp/graph.cpp
+++ b/src/python_interface/rcspp/graph.cpp
@@ -143,13 +143,11 @@ void init_graph(py::module_& m) {
                  py::arg("sink") = false,
                  py::return_value_policy::reference)
             .def("add_arc",
-                 py::overload_cast<size_t, size_t, double, std::vector<Row>, std::optional<size_t>>(
-                     &RealGraph::add_arc),
+                 py::overload_cast<size_t, size_t, double, std::vector<Row>>(&RealGraph::add_arc),
                  py::arg("origin_id"),
                  py::arg("destination_id"),
                  py::arg("cost") = 0.0,
                  py::arg("dual_rows") = std::vector<Row>{},
-                 py::arg("id") = std::nullopt,
                  py::return_value_policy::reference);
     }
 

--- a/src/python_interface/rcspp/graph.py
+++ b/src/python_interface/rcspp/graph.py
@@ -95,6 +95,7 @@ class ResourceGraph:
         # Buffers for deferred node/arc insertion
         self._node_buffer: list = []  # list of (id, source, sink)
         self._arc_buffer: list = []  # list of (raw_consumption, origin, dest, cost, rows)
+        self._rows_buffer: list = []  # list of (arc_id, row_index, coeff) triples
         self._reserve_hint: tuple[int, int] = (0, 0)  # (n_nodes, n_arcs) hint from reserve()
         self._next_arc_id: int = 0  # mirrors C++ next_arc_id_; returned by add_arc
         if nx_graph is not None:
@@ -176,7 +177,7 @@ class ResourceGraph:
         are allocated in a single shot instead of rehashing on every insert.
         """
         self._ensure_graph()
-        if not self._node_buffer and not self._arc_buffer:
+        if not self._node_buffer and not self._arc_buffer and not self._rows_buffer:
             return
         n_nodes = max(self._reserve_hint[0], self._graph.number_of_nodes() + len(self._node_buffer))
         n_arcs = max(self._reserve_hint[1], self._graph.number_of_arcs() + len(self._arc_buffer))
@@ -195,6 +196,12 @@ class ResourceGraph:
                 all_dual_rows.append(dual_rows)
             self._arc_buffer.clear()
             self._graph._add_arcs_bulk(consumptions, origins, dests, costs, all_dual_rows)
+        if self._rows_buffer:
+            import numpy as np
+
+            arr = np.array(self._rows_buffer, dtype=np.float64)
+            self._graph._add_rows_bulk(arr)
+            self._rows_buffer.clear()
 
     # ── Normalisation helper ──────────────────────────────────────────────────
 
@@ -231,6 +238,27 @@ class ResourceGraph:
             result[slot].append(item if isinstance(item, tuple) else (item,))
         return tuple(result)
 
+    @staticmethod
+    def _normalize_rows(rows) -> list:
+        """Normalise dual_rows to a list of Row objects.
+
+        Args:
+            rows: None, a single ``(index, coeff)`` tuple, a list of such tuples,
+                  or a list of :class:`Row` objects (passed through unchanged).
+
+        Returns:
+            A list of :class:`Row` objects.
+        """
+        if rows is None:
+            return []
+        _Row = _ext.graph.Row
+        if isinstance(rows, tuple) and len(rows) == 2:
+            return [_Row(int(rows[0]), float(rows[1]))]
+        result = []
+        for r in rows:
+            result.append(_Row(int(r[0]), float(r[1])) if isinstance(r, tuple) else r)
+        return result
+
     # ── Graph mutation (buffered) ─────────────────────────────────────────────
 
     def add_node(self, node_id: int, source: bool = False, sink: bool = False):
@@ -255,8 +283,7 @@ class ResourceGraph:
         operation to flush the buffer.  Arc resource normalization happens at flush
         time so resources must be registered before :meth:`update` is called.
         """
-        if dual_rows is None:
-            dual_rows = []
+        dual_rows = self._normalize_rows(dual_rows)
         arc_id = self._next_arc_id
         self._next_arc_id += 1
         self._arc_buffer.append(
@@ -360,6 +387,81 @@ class ResourceGraph:
         self._flush()
         norm_res_cons = self._normalize_consumption(resource_consumption)
         return self._graph.update_arc(arc, norm_res_cons, *args, **kwargs)
+
+    def add_rows_to_arc(self, arc_id: int, rows) -> None:
+        """Buffer rows to be appended to arc *arc_id*; applied at next flush/solve.
+
+        Args:
+            arc_id: Target arc ID.
+            rows: Single ``(index, coeff)`` tuple, a list of such tuples, or a
+                  list of :class:`Row` objects.
+        """
+        arc_id = int(arc_id)
+        if isinstance(rows, tuple) and len(rows) == 2:
+            rows = [rows]
+        for r in rows:
+            if isinstance(r, tuple):
+                self._rows_buffer.append((arc_id, int(r[0]), float(r[1])))
+            else:
+                self._rows_buffer.append((arc_id, int(r.index), float(r.coefficient)))
+
+    def add_rows(self, data) -> None:
+        """Buffer rows for multiple arcs at once; applied at next flush/solve.
+
+        Args:
+            data: Either a list of ``(arc_id, row_index, coeff)`` tuples or a
+                  2-D numpy array with shape ``(N, 3)`` and columns
+                  ``[arc_id, row_index, coeff]``.
+        """
+        if hasattr(data, "tolist"):
+            self._rows_buffer.extend(data.tolist())
+        else:
+            self._rows_buffer.extend(data)
+
+    def clone(
+        self, include_rows: bool = True, clone_removed_arcs: bool = False
+    ) -> "ResourceGraph":
+        """Return a deep clone of this ResourceGraph with stable arc IDs.
+
+        Flushes all pending buffers before cloning so the clone reflects the
+        complete current state.  The returned graph has an independent
+        remove/restore state and its own resource factory copy.
+
+        Args:
+            include_rows: Copy arc dual_rows into the clone (set *False* for a
+                topology-only clone to be populated via :meth:`add_rows`).
+            clone_removed_arcs: Also clone arcs currently removed from the
+                graph (they will be re-removed in the clone).
+
+        Returns:
+            A new :class:`ResourceGraph` wrapping the cloned C++ object.
+        """
+        self._flush()
+        cpp_clone = self._graph.clone(include_rows, clone_removed_arcs)
+        cloned = ResourceGraph.__new__(ResourceGraph)
+        cloned._pending = []
+        cloned._refs = list(self._refs)
+        cloned._graph = cpp_clone
+        cloned._graph_canonical = self._graph_canonical
+        cloned._registered_order = self._registered_order
+        cloned._full_registration_order = list(self._full_registration_order)
+        cloned._node_buffer = []
+        cloned._arc_buffer = []
+        cloned._rows_buffer = []
+        cloned._reserve_hint = (0, 0)
+        cloned._next_arc_id = cpp_clone.next_arc_id()
+        return cloned
+
+    def clone_topology(self) -> "ResourceGraph":
+        """Clone topology only (arc dual_rows are empty in the clone).
+
+        Use :meth:`add_rows` or :meth:`add_rows_to_arc` to populate rows per
+        (demand, time) slice after cloning.
+
+        Returns:
+            A new :class:`ResourceGraph` with no dual rows on arcs.
+        """
+        return self.clone(include_rows=False)
 
     def sort_nodes(self, comp=None):
         """Sort graph nodes in place.

--- a/src/python_interface/rcspp/graph.py
+++ b/src/python_interface/rcspp/graph.py
@@ -187,15 +187,15 @@ class ResourceGraph:
             self._graph._add_nodes_bulk(self._node_buffer)
             self._node_buffer.clear()
         if self._arc_buffer:
-            consumptions, origins, dests, costs, all_dual_rows = [], [], [], [], []
-            for raw_cons, origin_id, dest_id, cost, dual_rows in self._arc_buffer:
+            consumptions, origins, dests, costs, all_rows = [], [], [], [], []
+            for raw_cons, origin_id, dest_id, cost, rows in self._arc_buffer:
                 consumptions.append(self._normalize_consumption(raw_cons))
                 origins.append(origin_id)
                 dests.append(dest_id)
                 costs.append(cost)
-                all_dual_rows.append(dual_rows)
+                all_rows.append(rows)
             self._arc_buffer.clear()
-            self._graph._add_arcs_bulk(consumptions, origins, dests, costs, all_dual_rows)
+            self._graph._add_arcs_bulk(consumptions, origins, dests, costs, all_rows)
         if self._rows_buffer:
             import numpy as np
 
@@ -240,7 +240,7 @@ class ResourceGraph:
 
     @staticmethod
     def _normalize_rows(rows) -> list:
-        """Normalise dual_rows to a list of Row objects.
+        """Normalise rows to a list of Row objects.
 
         Args:
             rows: None, a single ``(index, coeff)`` tuple, a list of such tuples,
@@ -275,7 +275,7 @@ class ResourceGraph:
         origin_id: int,
         destination_id: int,
         cost: float = 0.0,
-        dual_rows=None,
+        rows=None,
     ):
         """Buffer an arc for insertion.
 
@@ -283,7 +283,7 @@ class ResourceGraph:
         operation to flush the buffer.  Arc resource normalization happens at flush
         time so resources must be registered before :meth:`update` is called.
         """
-        dual_rows = self._normalize_rows(dual_rows)
+        rows = self._normalize_rows(rows)
         arc_id = self._next_arc_id
         self._next_arc_id += 1
         self._arc_buffer.append(
@@ -292,7 +292,7 @@ class ResourceGraph:
                 int(origin_id),
                 int(destination_id),
                 float(cost),
-                dual_rows,
+                rows,
             )
         )
         return arc_id
@@ -418,9 +418,7 @@ class ResourceGraph:
         else:
             self._rows_buffer.extend(data)
 
-    def clone(
-        self, include_rows: bool = True, clone_removed_arcs: bool = False
-    ) -> "ResourceGraph":
+    def clone(self, include_rows: bool = True, clone_removed_arcs: bool = False) -> "ResourceGraph":
         """Return a deep clone of this ResourceGraph with stable arc IDs.
 
         Flushes all pending buffers before cloning so the clone reflects the
@@ -428,7 +426,7 @@ class ResourceGraph:
         remove/restore state and its own resource factory copy.
 
         Args:
-            include_rows: Copy arc dual_rows into the clone (set *False* for a
+            include_rows: Copy arc rows into the clone (set *False* for a
                 topology-only clone to be populated via :meth:`add_rows`).
             clone_removed_arcs: Also clone arcs currently removed from the
                 graph (they will be re-removed in the clone).
@@ -453,7 +451,7 @@ class ResourceGraph:
         return cloned
 
     def clone_topology(self) -> "ResourceGraph":
-        """Clone topology only (arc dual_rows are empty in the clone).
+        """Clone topology only (arc rows are empty in the clone).
 
         Use :meth:`add_rows` or :meth:`add_rows_to_arc` to populate rows per
         (demand, time) slice after cloning.
@@ -523,7 +521,7 @@ class ResourceGraph:
         For each arc, computes::
 
             reduced_cost = arc.cost - sum(row.coefficient * duals[row.index]
-                                          for row in arc.dual_rows)
+                                          for row in arc.rows)
 
         and writes ``reduced_cost`` to extender resource slot *cost_index*.
         ``arc.cost`` (base cost) is never modified, so repeated calls with
@@ -633,8 +631,8 @@ class ResourceGraph:
 
             resource_init = tuple(data["resource"])
             cost = data.get("cost", 0.0)
-            dual_rows = data.get("dual_rows", [])
-            self.add_arc(resource_init, int(u), int(v), cost, dual_rows)
+            rows = data.get("rows", [])
+            self.add_arc(resource_init, int(u), int(v), cost, rows)
 
         # Update the graph once everything is buffered
         self.update()

--- a/src/python_interface/rcspp/graph.py
+++ b/src/python_interface/rcspp/graph.py
@@ -550,12 +550,14 @@ class ResourceGraph:
             if not duals:
                 return  # honor the docstring: empty dict ⇒ leave reduced costs unchanged
             import numpy as np
+
             max_idx = max(duals.keys())
             duals_arr = np.zeros(max_idx + 1, dtype=np.float64)
             for k, v in duals.items():
                 duals_arr[k] = v
         else:
             import numpy as np
+
             # ascontiguousarray is a no-op when duals is already a C-contiguous
             # float64 ndarray (the common hot-path case), avoiding tolist() overhead.
             duals_arr = np.ascontiguousarray(duals, dtype=np.float64)

--- a/src/python_interface/rcspp/graph.py
+++ b/src/python_interface/rcspp/graph.py
@@ -549,11 +549,17 @@ class ResourceGraph:
         if isinstance(duals, dict):
             if not duals:
                 return  # honor the docstring: empty dict ⇒ leave reduced costs unchanged
+            import numpy as np
             max_idx = max(duals.keys())
-            duals_list = [duals.get(i, 0.0) for i in range(max_idx + 1)]
+            duals_arr = np.zeros(max_idx + 1, dtype=np.float64)
+            for k, v in duals.items():
+                duals_arr[k] = v
         else:
-            duals_list = duals.tolist() if hasattr(duals, "tolist") else list(duals)
-        self._graph.update_reduced_costs(duals_list, cost_index)
+            import numpy as np
+            # ascontiguousarray is a no-op when duals is already a C-contiguous
+            # float64 ndarray (the common hot-path case), avoiding tolist() overhead.
+            duals_arr = np.ascontiguousarray(duals, dtype=np.float64)
+        self._graph.update_reduced_costs(duals_arr, cost_index)
 
     # ── String representation ─────────────────────────────────────────────────
 

--- a/src/python_interface/rcspp/graph.py
+++ b/src/python_interface/rcspp/graph.py
@@ -94,8 +94,9 @@ class ResourceGraph:
         self._full_registration_order: list[str] = []  # per-instance, incl. duplicates
         # Buffers for deferred node/arc insertion
         self._node_buffer: list = []  # list of (id, source, sink)
-        self._arc_buffer: list = []  # list of (raw_consumption, origin, dest, cost, rows, arc_id)
+        self._arc_buffer: list = []  # list of (raw_consumption, origin, dest, cost, rows)
         self._reserve_hint: tuple[int, int] = (0, 0)  # (n_nodes, n_arcs) hint from reserve()
+        self._next_arc_id: int = 0  # mirrors C++ next_arc_id_; returned by add_arc
         if nx_graph is not None:
             self.from_networkx(nx_graph)
 
@@ -185,16 +186,15 @@ class ResourceGraph:
             self._graph._add_nodes_bulk(self._node_buffer)
             self._node_buffer.clear()
         if self._arc_buffer:
-            consumptions, origins, dests, costs, all_dual_rows, arc_ids = [], [], [], [], [], []
-            for raw_cons, origin_id, dest_id, cost, dual_rows, arc_id in self._arc_buffer:
+            consumptions, origins, dests, costs, all_dual_rows = [], [], [], [], []
+            for raw_cons, origin_id, dest_id, cost, dual_rows in self._arc_buffer:
                 consumptions.append(self._normalize_consumption(raw_cons))
                 origins.append(origin_id)
                 dests.append(dest_id)
                 costs.append(cost)
                 all_dual_rows.append(dual_rows)
-                arc_ids.append(arc_id)
             self._arc_buffer.clear()
-            self._graph._add_arcs_bulk(consumptions, origins, dests, costs, all_dual_rows, arc_ids)
+            self._graph._add_arcs_bulk(consumptions, origins, dests, costs, all_dual_rows)
 
     # ── Normalisation helper ──────────────────────────────────────────────────
 
@@ -248,7 +248,6 @@ class ResourceGraph:
         destination_id: int,
         cost: float = 0.0,
         dual_rows=None,
-        arc_id=None,
     ):
         """Buffer an arc for insertion.
 
@@ -258,6 +257,8 @@ class ResourceGraph:
         """
         if dual_rows is None:
             dual_rows = []
+        arc_id = self._next_arc_id
+        self._next_arc_id += 1
         self._arc_buffer.append(
             (
                 resource_consumption,
@@ -265,9 +266,9 @@ class ResourceGraph:
                 int(destination_id),
                 float(cost),
                 dual_rows,
-                arc_id,
             )
         )
+        return arc_id
 
     def remove_arcs(self, arc_ids):
         """Remove a batch of arcs by id.
@@ -529,10 +530,9 @@ class ResourceGraph:
                 )
 
             resource_init = tuple(data["resource"])
-            arc_id = data.get("id")
             cost = data.get("cost", 0.0)
             dual_rows = data.get("dual_rows", [])
-            self.add_arc(resource_init, int(u), int(v), cost, dual_rows, arc_id)
+            self.add_arc(resource_init, int(u), int(v), cost, dual_rows)
 
         # Update the graph once everything is buffered
         self.update()

--- a/src/python_interface/rcspp/graph_impl.hpp
+++ b/src/python_interface/rcspp/graph_impl.hpp
@@ -263,7 +263,13 @@ py::class_<G>& bind_graph_methods(py::class_<G>& c) {
              py::arg("destination_id"),
              py::return_value_policy::reference)
         .def("node_ids", &G::get_node_ids)
-        .def("arc_ids", &G::get_arc_ids)
+        .def("arc_ids",
+             [](const G& g) {
+                 std::vector<size_t> ids;
+                 ids.reserve(g.get_number_of_arcs());
+                 g.for_each_arc([&](const auto& arc) { ids.push_back(arc.id); });
+                 return ids;
+             })
         .def("source_node_ids", &G::get_source_node_ids)
         .def("sink_node_ids", &G::get_sink_node_ids)
         .def("number_of_nodes", &G::get_number_of_nodes)

--- a/src/python_interface/rcspp/graph_impl.hpp
+++ b/src/python_interface/rcspp/graph_impl.hpp
@@ -442,6 +442,7 @@ py::class_<RG, Graph<RC>>& bind_rg_methods(py::class_<RG, Graph<RC>>& c) {
             },
             py::arg("include_rows") = true,
             py::arg("clone_removed_arcs") = false,
+            py::call_guard<py::gil_scoped_release>(),
             "Clone this ResourceGraph. Arc IDs are stable across the clone. "
             "The clone has an independent remove/restore state.");
 }
@@ -510,9 +511,18 @@ void bind_resource_graph_impl(py::class_<RG, Graph<RC>>& rg) {
     if constexpr ((std::is_same_v<ResourceTypes, RealResource> || ...)) {
         rg.def(
             "update_reduced_costs",
-            [](RG& rg, const std::vector<double>& duals, size_t cost_index) {
+            [](RG& rg,
+               py::array_t<double, py::array::c_style | py::array::forcecast> duals_arr,
+               size_t cost_index) {
+                // Buffer access while GIL is held — just a pointer read (O(1)).
+                // Copy via fast memcpy into a vector, then release the GIL for
+                // the actual reduced-cost computation across all arcs.
+                auto buf = duals_arr.request();
+                std::vector<double> duals_vec(
+                    static_cast<const double*>(buf.ptr),
+                    static_cast<const double*>(buf.ptr) + buf.size);
                 ActiveCall::run_interruptible(
-                    [&] { rg.template update_reduced_costs<RealResource>(duals, cost_index); });
+                    [&] { rg.template update_reduced_costs<RealResource>(duals_vec, cost_index); });
             },
             py::arg("duals"),
             py::arg("cost_index") = 0);

--- a/src/python_interface/rcspp/graph_impl.hpp
+++ b/src/python_interface/rcspp/graph_impl.hpp
@@ -346,20 +346,18 @@ py::class_<G>& bind_graph_methods(py::class_<G>& c) {
              &G::add_rows_to_arc,
              py::arg("arc_id"),
              py::arg("rows"),
-             "Append rows to an arc's dual_rows. Returns false if arc_id is invalid.")
+             "Append rows to an arc's rows. Returns false if arc_id is invalid.")
         .def("next_arc_id",
              &G::next_arc_id,
              "Return the next arc ID that will be assigned by add_arc().")
         .def(
             "_add_rows_bulk",
-            [](G& g,
-               py::array_t<double, py::array::c_style | py::array::forcecast> rows) {
+            [](G& g, py::array_t<double, py::array::c_style | py::array::forcecast> rows) {
                 auto r = rows.unchecked<2>();
                 for (py::ssize_t i = 0; i < r.shape(0); ++i) {
-                    g.add_rows_to_arc(
-                        static_cast<size_t>(r(i, 0)),
-                        {Row{.index = static_cast<size_t>(r(i, 1)),
-                             .coefficient = static_cast<long double>(r(i, 2))}});
+                    g.add_rows_to_arc(static_cast<size_t>(r(i, 0)),
+                                      {Row{.index = static_cast<size_t>(r(i, 1)),
+                                           .coefficient = static_cast<long double>(r(i, 2))}});
                 }
             },
             py::arg("rows"),
@@ -480,7 +478,7 @@ void bind_resource_graph_impl(py::class_<RG, Graph<RC>>& rg) {
         py::arg("origin_node_id"),
         py::arg("destination_node_id"),
         py::arg("cost") = 0.0,
-        py::arg("dual_rows") = std::vector<Row>{},
+        py::arg("rows") = std::vector<Row>{},
         py::return_value_policy::reference);
 
     rg.def("update_arc",
@@ -497,16 +495,16 @@ void bind_resource_graph_impl(py::class_<RG, Graph<RC>>& rg) {
            const std::vector<size_t>& origins,
            const std::vector<size_t>& dests,
            const std::vector<double>& costs,
-           const std::vector<std::vector<Row>>& dual_rows) {
+           const std::vector<std::vector<Row>>& rows) {
             for (size_t i = 0; i < consumptions.size(); ++i) {
-                rg.add_arc(consumptions[i], origins[i], dests[i], costs[i], dual_rows[i]);
+                rg.add_arc(consumptions[i], origins[i], dests[i], costs[i], rows[i]);
             }
         },
         py::arg("consumptions"),
         py::arg("origin_ids"),
         py::arg("destination_ids"),
         py::arg("costs"),
-        py::arg("dual_rows"),
+        py::arg("rows"),
         py::call_guard<py::gil_scoped_release>());
 
     if constexpr ((std::is_same_v<ResourceTypes, RealResource> || ...)) {
@@ -544,7 +542,7 @@ void bind_resource_graph_block(py::module_& m, const char* rg_name, const char* 
             [](const Arc<RC>& a) -> Node<RC>* { return a.destination; },
             py::return_value_policy::reference)
         .def_readwrite("cost", &Arc<RC>::cost)
-        .def_readwrite("dual_rows", &Arc<RC>::dual_rows)
+        .def_readwrite("rows", &Arc<RC>::rows)
         .def("__str__", &Arc<RC>::to_string)
         .def("__repr__", &Arc<RC>::to_string);
 

--- a/src/python_interface/rcspp/graph_impl.hpp
+++ b/src/python_interface/rcspp/graph_impl.hpp
@@ -6,6 +6,7 @@
 // Must be defined before any pybind11 header is included.
 #define PYBIND11_USE_SMART_HOLDER_AS_DEFAULT
 
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -340,7 +341,30 @@ py::class_<G>& bind_graph_methods(py::class_<G>& c) {
             [](G& g, ArcType* arc) { return g.force_arc(*arc); },
             py::arg("arc"),
             "Remove all other out-arcs from the arc's origin and all other in-arcs to its "
-            "destination. Returns the ids of the removed arcs.");
+            "destination. Returns the ids of the removed arcs.")
+        .def("add_rows_to_arc",
+             &G::add_rows_to_arc,
+             py::arg("arc_id"),
+             py::arg("rows"),
+             "Append rows to an arc's dual_rows. Returns false if arc_id is invalid.")
+        .def("next_arc_id",
+             &G::next_arc_id,
+             "Return the next arc ID that will be assigned by add_arc().")
+        .def(
+            "_add_rows_bulk",
+            [](G& g,
+               py::array_t<double, py::array::c_style | py::array::forcecast> rows) {
+                auto r = rows.unchecked<2>();
+                for (py::ssize_t i = 0; i < r.shape(0); ++i) {
+                    g.add_rows_to_arc(
+                        static_cast<size_t>(r(i, 0)),
+                        {Row{.index = static_cast<size_t>(r(i, 1)),
+                             .coefficient = static_cast<long double>(r(i, 2))}});
+                }
+            },
+            py::arg("rows"),
+            py::call_guard<py::gil_scoped_release>(),
+            "Bulk-append rows from a (N, 3) float64 array [arc_id, row_index, coeff].");
 }
 
 // ─── Helper: bind common ResourceGraph methods ────────────────────────────────
@@ -412,7 +436,16 @@ py::class_<RG, Graph<RC>>& bind_rg_methods(py::class_<RG, Graph<RC>>& c) {
                 }
             },
             py::arg("nodes"),
-            py::call_guard<py::gil_scoped_release>());
+            py::call_guard<py::gil_scoped_release>())
+        .def(
+            "clone",
+            [](RG& rg, bool include_rows, bool clone_removed_arcs) {
+                return rg.clone(include_rows, clone_removed_arcs);
+            },
+            py::arg("include_rows") = true,
+            py::arg("clone_removed_arcs") = false,
+            "Clone this ResourceGraph. Arc IDs are stable across the clone. "
+            "The clone has an independent remove/restore state.");
 }
 
 // ─── Helper: bind one add_resource method ────────────────────────────────────

--- a/src/python_interface/rcspp/graph_impl.hpp
+++ b/src/python_interface/rcspp/graph_impl.hpp
@@ -512,15 +512,15 @@ void bind_resource_graph_impl(py::class_<RG, Graph<RC>>& rg) {
         rg.def(
             "update_reduced_costs",
             [](RG& rg,
-               py::array_t<double, py::array::c_style | py::array::forcecast> duals_arr,
+               py::array_t<double, py::array::c_style | py::array::forcecast>
+                   duals_arr,
                size_t cost_index) {
                 // Buffer access while GIL is held — just a pointer read (O(1)).
                 // Copy via fast memcpy into a vector, then release the GIL for
                 // the actual reduced-cost computation across all arcs.
                 auto buf = duals_arr.request();
-                std::vector<double> duals_vec(
-                    static_cast<const double*>(buf.ptr),
-                    static_cast<const double*>(buf.ptr) + buf.size);
+                std::vector<double> duals_vec(static_cast<const double*>(buf.ptr),
+                                              static_cast<const double*>(buf.ptr) + buf.size);
                 ActiveCall::run_interruptible(
                     [&] { rg.template update_reduced_costs<RealResource>(duals_vec, cost_index); });
             },

--- a/src/python_interface/rcspp/graph_impl.hpp
+++ b/src/python_interface/rcspp/graph_impl.hpp
@@ -439,20 +439,16 @@ void bind_resource_graph_impl(py::class_<RG, Graph<RC>>& rg) {
 
     (bind_add_resource<RG, RC, ResourceTypes>(rg), ...);
 
-    rg.def("add_arc",
-           static_cast<Arc<RC>& (RG::*)(const AddArcTuple&,
-                                        size_t,
-                                        size_t,
-                                        double,
-                                        std::vector<Row>,
-                                        std::optional<size_t>)>(&RG::add_arc),
-           py::arg("resource_consumption"),
-           py::arg("origin_node_id"),
-           py::arg("destination_node_id"),
-           py::arg("cost") = 0.0,
-           py::arg("dual_rows") = std::vector<Row>{},
-           py::arg("id") = std::nullopt,
-           py::return_value_policy::reference);
+    rg.def(
+        "add_arc",
+        static_cast<Arc<RC>& (RG::*)(const AddArcTuple&, size_t, size_t, double, std::vector<Row>)>(
+            &RG::add_arc),
+        py::arg("resource_consumption"),
+        py::arg("origin_node_id"),
+        py::arg("destination_node_id"),
+        py::arg("cost") = 0.0,
+        py::arg("dual_rows") = std::vector<Row>{},
+        py::return_value_policy::reference);
 
     rg.def("update_arc",
            static_cast<void (RG::*)(Arc<RC>*, const AddArcTuple&, std::optional<double>)>(
@@ -468,15 +464,9 @@ void bind_resource_graph_impl(py::class_<RG, Graph<RC>>& rg) {
            const std::vector<size_t>& origins,
            const std::vector<size_t>& dests,
            const std::vector<double>& costs,
-           const std::vector<std::vector<Row>>& dual_rows,
-           const std::vector<std::optional<size_t>>& arc_ids) {
+           const std::vector<std::vector<Row>>& dual_rows) {
             for (size_t i = 0; i < consumptions.size(); ++i) {
-                rg.add_arc(consumptions[i],
-                           origins[i],
-                           dests[i],
-                           costs[i],
-                           dual_rows[i],
-                           arc_ids[i]);
+                rg.add_arc(consumptions[i], origins[i], dests[i], costs[i], dual_rows[i]);
             }
         },
         py::arg("consumptions"),
@@ -484,7 +474,6 @@ void bind_resource_graph_impl(py::class_<RG, Graph<RC>>& rg) {
         py::arg("destination_ids"),
         py::arg("costs"),
         py::arg("dual_rows"),
-        py::arg("arc_ids"),
         py::call_guard<py::gil_scoped_release>());
 
     if constexpr ((std::is_same_v<ResourceTypes, RealResource> || ...)) {

--- a/src/rcspp/algorithm/algorithm.hpp
+++ b/src/rcspp/algorithm/algorithm.hpp
@@ -275,7 +275,7 @@ class Algorithm {
                 const auto* arc = this->graph_->get_arc(arc_id);
                 path_node_ids.push_back(arc->origin->id);
                 column.cost += arc->cost;
-                for (const auto& row : arc->dual_rows) {
+                for (const auto& row : arc->rows) {
                     row_map[row.index] += row.coefficient;
                 }
             }

--- a/src/rcspp/graph/arc.hpp
+++ b/src/rcspp/graph/arc.hpp
@@ -23,21 +23,21 @@ class Arc {
     public:
         Arc(size_t arc_id, Node<ResourceType>* origin_node, Node<ResourceType>* destination_node,
             std::unique_ptr<Extender<ResourceType>> arc_extender, double arc_cost,
-            std::vector<Row> dual_rows = {})
+            std::vector<Row> rows = {})
             : id(arc_id),
               origin(origin_node),
               destination(destination_node),
               extender(std::move(arc_extender)),
               cost(arc_cost),
-              dual_rows(std::move(dual_rows)) {}
+              rows(std::move(rows)) {}
 
         Arc(size_t arc_id, Node<ResourceType>* origin_node, Node<ResourceType>* destination_node,
-            double arc_cost, std::vector<Row> dual_rows = {})
-            : Arc(arc_id, origin_node, destination_node, nullptr, arc_cost, std::move(dual_rows)) {}
+            double arc_cost, std::vector<Row> rows = {})
+            : Arc(arc_id, origin_node, destination_node, nullptr, arc_cost, std::move(rows)) {}
 
         Arc(size_t arc_id, Node<ResourceType>* origin_node, Node<ResourceType>* destination_node,
-            std::vector<Row> dual_rows = {})
-            : Arc(arc_id, origin_node, destination_node, 0, std::move(dual_rows)) {}
+            std::vector<Row> rows = {})
+            : Arc(arc_id, origin_node, destination_node, 0, std::move(rows)) {}
 
         const size_t id;
 
@@ -49,7 +49,7 @@ class Arc {
 
         double cost;
 
-        std::vector<Row> dual_rows;
+        std::vector<Row> rows;
 
         [[nodiscard]] std::string to_string() const {
             std::stringstream ss;

--- a/src/rcspp/graph/graph.hpp
+++ b/src/rcspp/graph/graph.hpp
@@ -8,7 +8,6 @@
 #include <concepts>  // NOLINT(build/include_order)
 #include <functional>
 #include <memory>
-#include <optional>
 #include <ranges>  // NOLINT(build/include_order)
 #include <span>
 #include <string>
@@ -56,21 +55,25 @@ class Graph {
 
             // copy active arcs in id order (preserves id→slot mapping in the cloned vector)
             for_each_arc([&](const auto& arc_ref) {
-                auto& arc = new_graph->add_arc(arc_ref.origin->id,
-                                               arc_ref.destination->id,
-                                               arc_ref.cost,
-                                               arc_ref.dual_rows,
-                                               arc_ref.id);
+                auto* origin = new_graph->get_node(arc_ref.origin->id);
+                auto* dest = new_graph->get_node(arc_ref.destination->id);
+                auto& arc = new_graph->add_arc_at(origin,
+                                                  dest,
+                                                  arc_ref.cost,
+                                                  arc_ref.dual_rows,
+                                                  arc_ref.id);
                 arc.extender = arc_ref.extender ? std::move(arc_ref.extender->clone(arc)) : nullptr;
             });
 
             if (clone_removed_arcs) {
                 for (const auto& [arc_id, arc_ptr] : removed_arcs_by_id_) {
-                    auto& arc = new_graph->add_arc(arc_ptr->origin->id,
-                                                   arc_ptr->destination->id,
-                                                   arc_ptr->cost,
-                                                   arc_ptr->dual_rows,
-                                                   arc_id);
+                    auto* origin = new_graph->get_node(arc_ptr->origin->id);
+                    auto* dest = new_graph->get_node(arc_ptr->destination->id);
+                    auto& arc = new_graph->add_arc_at(origin,
+                                                      dest,
+                                                      arc_ptr->cost,
+                                                      arc_ptr->dual_rows,
+                                                      arc_id);
                     new_graph->remove_arc(arc_id);
                     arc.extender =
                         arc_ptr->extender ? std::move(arc_ptr->extender->clone(arc)) : nullptr;
@@ -99,38 +102,16 @@ class Graph {
 
         virtual Arc<ResourceType>& add_arc(Node<ResourceType>* origin_node,
                                            Node<ResourceType>* destination_node, double cost = 0.0,
-                                           std::vector<Row> dual_rows = {},
-                                           std::optional<size_t> arc_id = std::nullopt) {
-            if (arc_id == std::nullopt) {
-                arc_id = next_arc_id_;
-            }
-            next_arc_id_ = std::max(next_arc_id_, *arc_id + 1);
-
-            if (*arc_id >= arcs_.size()) {
-                arcs_.resize(*arc_id + 1);
-            }
-            arcs_[*arc_id] = std::make_unique<Arc<ResourceType>>(*arc_id,
-                                                                 origin_node,
-                                                                 destination_node,
-                                                                 cost,
-                                                                 dual_rows);
-            ++active_arc_count_;
-            modified_ = true;
-            csr_valid_ = false;
-
-            origin_node->out_arcs.push_back(arcs_[*arc_id].get());
-            destination_node->in_arcs.push_back(arcs_[*arc_id].get());
-
-            return *arcs_[*arc_id];
+                                           std::vector<Row> dual_rows = {}) {
+            return add_arc_at(origin_node, destination_node, cost, dual_rows, next_arc_id_);
         }
 
         virtual Arc<ResourceType>& add_arc(size_t origin_node_id, size_t destination_node_id,
-                                           double cost = 0.0, std::vector<Row> dual_rows = {},
-                                           std::optional<size_t> arc_id = std::nullopt) {
+                                           double cost = 0.0, std::vector<Row> dual_rows = {}) {
             auto& origin_node = nodes_by_id_.at(origin_node_id);
             auto& destination_node = nodes_by_id_.at(destination_node_id);
 
-            return add_arc(origin_node.get(), destination_node.get(), cost, dual_rows, arc_id);
+            return add_arc(origin_node.get(), destination_node.get(), cost, dual_rows);
         }
 
         virtual bool remove_arc(size_t arc_id) {
@@ -492,6 +473,27 @@ class Graph {
         mutable std::vector<Arc<ResourceType>*> csr_out_arcs_;
         mutable std::vector<Arc<ResourceType>*> csr_in_arcs_;
         mutable bool csr_valid_ = false;
+
+        // Internal helper: insert an arc at a specific slot (used by clone()).
+        Arc<ResourceType>& add_arc_at(Node<ResourceType>* origin_node,
+                                      Node<ResourceType>* destination_node, double cost,
+                                      std::vector<Row> dual_rows, size_t arc_id) {
+            next_arc_id_ = std::max(next_arc_id_, arc_id + 1);
+            if (arc_id >= arcs_.size()) {
+                arcs_.resize(arc_id + 1);
+            }
+            arcs_[arc_id] = std::make_unique<Arc<ResourceType>>(arc_id,
+                                                                origin_node,
+                                                                destination_node,
+                                                                cost,
+                                                                dual_rows);
+            ++active_arc_count_;
+            modified_ = true;
+            csr_valid_ = false;
+            origin_node->out_arcs.push_back(arcs_[arc_id].get());
+            destination_node->in_arcs.push_back(arcs_[arc_id].get());
+            return *arcs_[arc_id];
+        }
 
         // Internal helper: restore one arc while iterating removed_arcs_by_id_.
         typename ArcMap::iterator restore_arc_from_map(typename ArcMap::iterator it) {

--- a/src/rcspp/graph/graph.hpp
+++ b/src/rcspp/graph/graph.hpp
@@ -58,16 +58,16 @@ class Graph {
 
         virtual Arc<ResourceType>& add_arc(Node<ResourceType>* origin_node,
                                            Node<ResourceType>* destination_node, double cost = 0.0,
-                                           std::vector<Row> dual_rows = {}) {
-            return add_arc_at(origin_node, destination_node, cost, dual_rows, next_arc_id_);
+                                           std::vector<Row> rows = {}) {
+            return add_arc_at(origin_node, destination_node, cost, rows, next_arc_id_);
         }
 
         virtual Arc<ResourceType>& add_arc(size_t origin_node_id, size_t destination_node_id,
-                                           double cost = 0.0, std::vector<Row> dual_rows = {}) {
+                                           double cost = 0.0, std::vector<Row> rows = {}) {
             auto& origin_node = nodes_by_id_.at(origin_node_id);
             auto& destination_node = nodes_by_id_.at(destination_node_id);
 
-            return add_arc(origin_node.get(), destination_node.get(), cost, dual_rows);
+            return add_arc(origin_node.get(), destination_node.get(), cost, rows);
         }
 
         virtual bool remove_arc(size_t arc_id) {
@@ -292,13 +292,13 @@ class Graph {
 
         [[nodiscard]] size_t get_number_of_arcs() const { return active_arc_count_; }
 
-        /// @brief Append *rows* to the dual_rows of arc *arc_id*.
+        /// @brief Append *rows* to the rows of arc *arc_id*.
         /// @return True if the arc was found and updated, false if *arc_id* is invalid.
         bool add_rows_to_arc(size_t arc_id, const std::vector<Row>& rows) {
             if (arc_id >= arcs_.size() || !arcs_[arc_id]) {
                 return false;
             }
-            auto& dr = arcs_[arc_id]->dual_rows;
+            auto& dr = arcs_[arc_id]->rows;
             dr.insert(dr.end(), rows.begin(), rows.end());
             return true;
         }
@@ -432,7 +432,7 @@ class Graph {
         /// the resource is then overridden with a clone of the original's resource.
         ///
         /// @param target            Graph to fill; must be empty on entry.
-        /// @param include_rows      When false, arc dual_rows are left empty.
+        /// @param include_rows      When false, arc rows are left empty.
         /// @param clone_removed_arcs Also copy removed arcs (re-removed in target).
         void clone_topology_into(Graph<ResourceType>& target, bool include_rows,
                                  bool clone_removed_arcs) const {
@@ -452,20 +452,23 @@ class Graph {
             for_each_arc([&](const auto& arc_ref) {
                 auto* origin = target.get_node(arc_ref.origin->id);
                 auto* dest = target.get_node(arc_ref.destination->id);
-                auto& arc = target.add_arc_at(
-                    origin, dest, arc_ref.cost,
-                    include_rows ? arc_ref.dual_rows : std::vector<Row>{}, arc_ref.id);
-                arc.extender =
-                    arc_ref.extender ? std::move(arc_ref.extender->clone(arc)) : nullptr;
+                auto& arc = target.add_arc_at(origin,
+                                              dest,
+                                              arc_ref.cost,
+                                              include_rows ? arc_ref.rows : std::vector<Row>{},
+                                              arc_ref.id);
+                arc.extender = arc_ref.extender ? std::move(arc_ref.extender->clone(arc)) : nullptr;
             });
 
             if (clone_removed_arcs) {
                 for (const auto& [arc_id, arc_ptr] : removed_arcs_by_id_) {
                     auto* origin = target.get_node(arc_ptr->origin->id);
                     auto* dest = target.get_node(arc_ptr->destination->id);
-                    auto& arc = target.add_arc_at(
-                        origin, dest, arc_ptr->cost,
-                        include_rows ? arc_ptr->dual_rows : std::vector<Row>{}, arc_id);
+                    auto& arc = target.add_arc_at(origin,
+                                                  dest,
+                                                  arc_ptr->cost,
+                                                  include_rows ? arc_ptr->rows : std::vector<Row>{},
+                                                  arc_id);
                     arc.extender =
                         arc_ptr->extender ? std::move(arc_ptr->extender->clone(arc)) : nullptr;
                     target.remove_arc(arc_id);
@@ -499,7 +502,7 @@ class Graph {
         // Internal helper: insert an arc at a specific slot (used by clone()).
         Arc<ResourceType>& add_arc_at(Node<ResourceType>* origin_node,
                                       Node<ResourceType>* destination_node, double cost,
-                                      std::vector<Row> dual_rows, size_t arc_id) {
+                                      std::vector<Row> rows, size_t arc_id) {
             next_arc_id_ = std::max(next_arc_id_, arc_id + 1);
             if (arc_id >= arcs_.size()) {
                 arcs_.resize(arc_id + 1);
@@ -508,7 +511,7 @@ class Graph {
                                                                 origin_node,
                                                                 destination_node,
                                                                 cost,
-                                                                dual_rows);
+                                                                rows);
             ++active_arc_count_;
             modified_ = true;
             csr_valid_ = false;

--- a/src/rcspp/graph/graph.hpp
+++ b/src/rcspp/graph/graph.hpp
@@ -35,51 +35,7 @@ class Graph {
         [[nodiscard]] std::unique_ptr<Graph<ResourceType>> clone(
             bool clone_removed_arcs = false) const {
             auto new_graph = std::make_unique<Graph<ResourceType>>();
-
-            // reserve the right size
-            new_graph->reserve(get_nodes_size(), get_arcs_size());
-
-            // copy nodes
-            for (const auto& [node_id, node_ptr] : nodes_by_id_) {
-                auto& node = new_graph->add_node(node_id, node_ptr->source, node_ptr->sink);
-                node.resource =
-                    node_ptr->resource ? std::move(node_ptr->resource->clone()) : nullptr;
-            }
-
-            // copy sorted nodes
-            for (const auto* node_ptr : sorted_nodes_) {
-                auto* node = new_graph->get_node(node_ptr->id);
-                node->pos_ = node_ptr->pos_;
-                new_graph->sorted_nodes_.push_back(node);
-            }
-
-            // copy active arcs in id order (preserves id→slot mapping in the cloned vector)
-            for_each_arc([&](const auto& arc_ref) {
-                auto* origin = new_graph->get_node(arc_ref.origin->id);
-                auto* dest = new_graph->get_node(arc_ref.destination->id);
-                auto& arc = new_graph->add_arc_at(origin,
-                                                  dest,
-                                                  arc_ref.cost,
-                                                  arc_ref.dual_rows,
-                                                  arc_ref.id);
-                arc.extender = arc_ref.extender ? std::move(arc_ref.extender->clone(arc)) : nullptr;
-            });
-
-            if (clone_removed_arcs) {
-                for (const auto& [arc_id, arc_ptr] : removed_arcs_by_id_) {
-                    auto* origin = new_graph->get_node(arc_ptr->origin->id);
-                    auto* dest = new_graph->get_node(arc_ptr->destination->id);
-                    auto& arc = new_graph->add_arc_at(origin,
-                                                      dest,
-                                                      arc_ptr->cost,
-                                                      arc_ptr->dual_rows,
-                                                      arc_id);
-                    new_graph->remove_arc(arc_id);
-                    arc.extender =
-                        arc_ptr->extender ? std::move(arc_ptr->extender->clone(arc)) : nullptr;
-                }
-            }
-
+            clone_topology_into(*new_graph, /*include_rows=*/true, clone_removed_arcs);
             return new_graph;
         }
 
@@ -336,6 +292,20 @@ class Graph {
 
         [[nodiscard]] size_t get_number_of_arcs() const { return active_arc_count_; }
 
+        /// @brief Append *rows* to the dual_rows of arc *arc_id*.
+        /// @return True if the arc was found and updated, false if *arc_id* is invalid.
+        bool add_rows_to_arc(size_t arc_id, const std::vector<Row>& rows) {
+            if (arc_id >= arcs_.size() || !arcs_[arc_id]) {
+                return false;
+            }
+            auto& dr = arcs_[arc_id]->dual_rows;
+            dr.insert(dr.end(), rows.begin(), rows.end());
+            return true;
+        }
+
+        /// @brief Return the next arc ID that will be assigned by add_arc().
+        [[nodiscard]] size_t next_arc_id() const { return next_arc_id_; }
+
         // Pre-allocate storage to avoid reallocation during bulk inserts.
         void reserve(size_t n_nodes, size_t n_arcs) {
             nodes_by_id_.reserve(n_nodes);
@@ -449,6 +419,58 @@ class Graph {
                 for_each_arc([&](const auto& arc) { ss << arc; });
             }
             return ss.str();
+        }
+
+    protected:
+        /// @brief Copy nodes, sorted-node order, and arcs from *this* into *target*.
+        ///
+        /// Called by clone() and by ResourceGraph::clone(). Being a Graph<ResourceType>
+        /// member it has access to all private fields of both *this* and *target*
+        /// (nodes_by_id_, sorted_nodes_, removed_arcs_by_id_, add_arc_at).
+        /// Node creation goes through target.add_node() (virtual) so that a
+        /// ResourceGraph target correctly initialises node resources from its factory;
+        /// the resource is then overridden with a clone of the original's resource.
+        ///
+        /// @param target            Graph to fill; must be empty on entry.
+        /// @param include_rows      When false, arc dual_rows are left empty.
+        /// @param clone_removed_arcs Also copy removed arcs (re-removed in target).
+        void clone_topology_into(Graph<ResourceType>& target, bool include_rows,
+                                 bool clone_removed_arcs) const {
+            target.reserve(get_nodes_size(), get_arcs_size());
+
+            for (const auto& [node_id, node_ptr] : nodes_by_id_) {
+                auto& node = target.add_node(node_id, node_ptr->source, node_ptr->sink);
+                node.resource = node_ptr->resource ? node_ptr->resource->clone() : nullptr;
+            }
+
+            for (const auto* node_ptr : sorted_nodes_) {
+                auto* node = target.get_node(node_ptr->id);
+                node->pos_ = node_ptr->pos_;
+                target.sorted_nodes_.push_back(node);
+            }
+
+            for_each_arc([&](const auto& arc_ref) {
+                auto* origin = target.get_node(arc_ref.origin->id);
+                auto* dest = target.get_node(arc_ref.destination->id);
+                auto& arc = target.add_arc_at(
+                    origin, dest, arc_ref.cost,
+                    include_rows ? arc_ref.dual_rows : std::vector<Row>{}, arc_ref.id);
+                arc.extender =
+                    arc_ref.extender ? std::move(arc_ref.extender->clone(arc)) : nullptr;
+            });
+
+            if (clone_removed_arcs) {
+                for (const auto& [arc_id, arc_ptr] : removed_arcs_by_id_) {
+                    auto* origin = target.get_node(arc_ptr->origin->id);
+                    auto* dest = target.get_node(arc_ptr->destination->id);
+                    auto& arc = target.add_arc_at(
+                        origin, dest, arc_ptr->cost,
+                        include_rows ? arc_ptr->dual_rows : std::vector<Row>{}, arc_id);
+                    arc.extender =
+                        arc_ptr->extender ? std::move(arc_ptr->extender->clone(arc)) : nullptr;
+                    target.remove_arc(arc_id);
+                }
+            }
         }
 
     private:

--- a/src/rcspp/graph/graph.hpp
+++ b/src/rcspp/graph/graph.hpp
@@ -54,19 +54,17 @@ class Graph {
                 new_graph->sorted_nodes_.push_back(node);
             }
 
-            // copy arcs
-            for (const auto& [arc_id, arc_ptr] : arcs_by_id_) {
-                auto& arc = new_graph->add_arc(arc_ptr->origin->id,
-                                               arc_ptr->destination->id,
-                                               arc_ptr->cost,
-                                               arc_ptr->dual_rows,
-                                               arc_id);
-                arc.extender =
-                    arc_ptr->extender ? std::move(arc_ptr->extender->clone(arc)) : nullptr;
-            }
+            // copy active arcs in id order (preserves id→slot mapping in the cloned vector)
+            for_each_arc([&](const auto& arc_ref) {
+                auto& arc = new_graph->add_arc(arc_ref.origin->id,
+                                               arc_ref.destination->id,
+                                               arc_ref.cost,
+                                               arc_ref.dual_rows,
+                                               arc_ref.id);
+                arc.extender = arc_ref.extender ? std::move(arc_ref.extender->clone(arc)) : nullptr;
+            });
 
             if (clone_removed_arcs) {
-                // copy removed arcs
                 for (const auto& [arc_id, arc_ptr] : removed_arcs_by_id_) {
                     auto& arc = new_graph->add_arc(arc_ptr->origin->id,
                                                    arc_ptr->destination->id,
@@ -108,19 +106,22 @@ class Graph {
             }
             next_arc_id_ = std::max(next_arc_id_, *arc_id + 1);
 
-            auto& new_arc = arcs_by_id_[*arc_id] =
-                std::make_unique<Arc<ResourceType>>(*arc_id,
-                                                    origin_node,
-                                                    destination_node,
-                                                    cost,
-                                                    dual_rows);
+            if (*arc_id >= arcs_.size()) {
+                arcs_.resize(*arc_id + 1);
+            }
+            arcs_[*arc_id] = std::make_unique<Arc<ResourceType>>(*arc_id,
+                                                                 origin_node,
+                                                                 destination_node,
+                                                                 cost,
+                                                                 dual_rows);
+            ++active_arc_count_;
             modified_ = true;
             csr_valid_ = false;
 
-            origin_node->out_arcs.push_back(new_arc.get());
-            destination_node->in_arcs.push_back(new_arc.get());
+            origin_node->out_arcs.push_back(arcs_[*arc_id].get());
+            destination_node->in_arcs.push_back(arcs_[*arc_id].get());
 
-            return *new_arc.get();
+            return *arcs_[*arc_id];
         }
 
         virtual Arc<ResourceType>& add_arc(size_t origin_node_id, size_t destination_node_id,
@@ -133,11 +134,30 @@ class Graph {
         }
 
         virtual bool remove_arc(size_t arc_id) {
-            auto it = arcs_by_id_.find(arc_id);
-            if (it == arcs_by_id_.end()) {
+            if (arc_id >= arcs_.size() || !arcs_[arc_id]) {
                 return false;
             }
-            remove_arc(it);
+
+            Arc<ResourceType>& arc = *arcs_[arc_id];
+
+            auto& in_arcs = arc.destination->in_arcs;
+            in_arcs.erase(
+                std::remove_if(in_arcs.begin(),
+                               in_arcs.end(),
+                               [arc_id](Arc<ResourceType>* a) { return a->id == arc_id; }),
+                in_arcs.end());
+
+            auto& out_arcs = arc.origin->out_arcs;
+            out_arcs.erase(
+                std::remove_if(out_arcs.begin(),
+                               out_arcs.end(),
+                               [arc_id](Arc<ResourceType>* a) { return a->id == arc_id; }),
+                out_arcs.end());
+
+            removed_arcs_by_id_.emplace(arc_id, std::move(arcs_[arc_id]));
+            --active_arc_count_;
+            modified_ = true;
+            csr_valid_ = false;
             return true;
         }
 
@@ -155,27 +175,14 @@ class Graph {
             return removed;
         }
 
-        // Restore a batch of arcs by id. Returns the ids that were actually restored.
-        std::vector<size_t> restore_arcs(const std::vector<size_t>& arc_ids) {
-            std::vector<size_t> restored;
-            restored.reserve(arc_ids.size());
-            for (size_t id : arc_ids) {
-                if (restore_arc(id)) {
-                    restored.push_back(id);
-                }
-            }
-            return restored;
-        }
-
         // Force an arc: remove all other out-arcs from its origin and all other
         // in-arcs to its destination, keeping only this arc active on both ends.
         // Returns the ids of the arcs that were removed.
         std::vector<size_t> force_arc(size_t arc_id) {
-            auto it = arcs_by_id_.find(arc_id);
-            if (it == arcs_by_id_.end()) {
+            if (arc_id >= arcs_.size() || !arcs_[arc_id]) {
                 return {};
             }
-            Arc<ResourceType>& arc = *it->second;
+            Arc<ResourceType>& arc = *arcs_[arc_id];
 
             std::vector<size_t> to_remove;
             for (auto* a : arc.origin->out_arcs) {
@@ -203,17 +210,16 @@ class Graph {
 
         template <typename C>
         std::vector<size_t> remove_arcs_if(C check) {
-            std::vector<size_t> deleted_arc_ids;
-            for (auto it = arcs_by_id_.begin(); it != arcs_by_id_.end();) {
-                // check if we should remove the arc
-                if (check(*it->second)) {
-                    deleted_arc_ids.push_back(it->first);
-                    it = remove_arc(it);
-                } else {
-                    ++it;
+            std::vector<size_t> to_remove;
+            for_each_arc([&](const auto& arc) {
+                if (check(arc)) {
+                    to_remove.push_back(arc.id);
                 }
+            });
+            for (size_t id : to_remove) {
+                remove_arc(id);
             }
-            return deleted_arc_ids;
+            return to_remove;
         }
 
         virtual bool restore_arc(size_t arc_id) {
@@ -221,20 +227,43 @@ class Graph {
             if (it == removed_arcs_by_id_.end()) {
                 return false;
             }
-            restore_arc(it);
+
+            Arc<ResourceType>* arc = it->second.get();
+            arc->destination->in_arcs.push_back(arc);
+            arc->origin->out_arcs.push_back(arc);
+
+            if (arc_id >= arcs_.size()) {
+                arcs_.resize(arc_id + 1);
+            }
+            arcs_[arc_id] = std::move(it->second);
+            removed_arcs_by_id_.erase(it);
+            ++active_arc_count_;
+            modified_ = true;
+            csr_valid_ = false;
             return true;
         }
 
         virtual bool restore_arc(const Arc<ResourceType>& arc) { return restore_arc(arc.id); }
 
+        // Restore a batch of arcs by id. Returns the ids that were actually restored.
+        std::vector<size_t> restore_arcs(const std::vector<size_t>& arc_ids) {
+            std::vector<size_t> restored;
+            restored.reserve(arc_ids.size());
+            for (size_t id : arc_ids) {
+                if (restore_arc(id)) {
+                    restored.push_back(id);
+                }
+            }
+            return restored;
+        }
+
         template <typename C>
         std::vector<size_t> restore_arcs_if(C check) {
             std::vector<size_t> restored_arc_ids;
             for (auto it = removed_arcs_by_id_.begin(); it != removed_arcs_by_id_.end();) {
-                // check if we should remove the arc
                 if (check(*it->second)) {
                     restored_arc_ids.push_back(it->first);
-                    it = restore_arc(it);
+                    it = restore_arc_from_map(it);
                 } else {
                     ++it;
                 }
@@ -251,11 +280,10 @@ class Graph {
         }
 
         [[nodiscard]] Arc<ResourceType>* get_arc(size_t arc_id) const {
-            auto it = arcs_by_id_.find(arc_id);
-            if (it == arcs_by_id_.end()) {
+            if (arc_id >= arcs_.size()) {
                 return nullptr;
             }
-            return it->second.get();
+            return arcs_[arc_id].get();
         }
 
         [[nodiscard]] std::vector<Arc<ResourceType>*> get_arcs(size_t ori_id,
@@ -284,17 +312,17 @@ class Graph {
 
         [[nodiscard]] size_t get_nodes_size() const { return nodes_by_id_.size(); }
 
-        [[nodiscard]] std::vector<size_t> get_arc_ids() const {
-            std::vector<size_t> ids;
-            ids.reserve(arcs_by_id_.size());
-            for (const auto& [k, _] : arcs_by_id_) {
-                ids.push_back(k);
+        // Iterate over all active arcs without allocating. fn receives a const Arc& reference.
+        template <typename F>
+        void for_each_arc(F&& fn) const {
+            for (const auto& arc : arcs_) {
+                if (arc) {
+                    fn(*arc);
+                }
             }
-            std::sort(ids.begin(), ids.end());
-            return ids;
         }
 
-        [[nodiscard]] size_t get_arcs_size() const { return arcs_by_id_.size(); }
+        [[nodiscard]] size_t get_arcs_size() const { return active_arc_count_; }
 
         [[nodiscard]] std::vector<size_t> get_removed_arc_ids() const {
             std::vector<size_t> ids;
@@ -311,11 +339,6 @@ class Graph {
             return it != removed_arcs_by_id_.end() ? it->second.get() : nullptr;
         }
 
-        [[nodiscard]] const std::unordered_map<size_t, std::unique_ptr<Arc<ResourceType>>>&
-        get_arcs_by_id() const {
-            return arcs_by_id_;
-        }
-
         [[nodiscard]] const std::vector<Node<ResourceType>*>& get_sorted_nodes() const {
             return sorted_nodes_;
         }
@@ -330,12 +353,12 @@ class Graph {
 
         [[nodiscard]] size_t get_number_of_nodes() const { return nodes_by_id_.size(); }
 
-        [[nodiscard]] size_t get_number_of_arcs() const { return arcs_by_id_.size(); }
+        [[nodiscard]] size_t get_number_of_arcs() const { return active_arc_count_; }
 
-        // Pre-allocate hash-map buckets to avoid rehashing during bulk inserts.
+        // Pre-allocate storage to avoid reallocation during bulk inserts.
         void reserve(size_t n_nodes, size_t n_arcs) {
             nodes_by_id_.reserve(n_nodes);
-            arcs_by_id_.reserve(n_arcs);
+            arcs_.reserve(n_arcs);
         }
 
         [[nodiscard]] bool is_source(size_t node_id) const {
@@ -354,17 +377,12 @@ class Graph {
 
         template <class Compare>
         void sort_nodes(Compare comp) {
-            // populate the vector
             sorted_nodes_.clear();
             sorted_nodes_.reserve(nodes_by_id_.size());
             for (auto& [node_id, node_ptr] : nodes_by_id_) {
                 sorted_nodes_.push_back(node_ptr.get());
             }
-
-            // sort
             std::stable_sort(sorted_nodes_.begin(), sorted_nodes_.end(), comp);
-
-            // fix position
             size_t i = 0;
             for (const auto& node_ptr : sorted_nodes_) {
                 node_ptr->pos_ = i++;
@@ -447,9 +465,7 @@ class Graph {
                 ss << *nodes_by_id_.at(id) << "\n";
             }
             if (print_arcs) {
-                for (size_t id : get_arc_ids()) {
-                    ss << *arcs_by_id_.at(id);
-                }
+                for_each_arc([&](const auto& arc) { ss << arc; });
             }
             return ss.str();
         }
@@ -458,7 +474,10 @@ class Graph {
         using ArcMap = std::unordered_map<size_t, std::unique_ptr<Arc<ResourceType>>>;
         using NodeMap = std::unordered_map<size_t, std::unique_ptr<Node<ResourceType>>>;
 
-        ArcMap arcs_by_id_;
+        // Arc storage: indexed directly by arc_id. nullptr slots are removed arcs.
+        std::vector<std::unique_ptr<Arc<ResourceType>>> arcs_;
+        size_t active_arc_count_ = 0;
+
         NodeMap nodes_by_id_;
         std::vector<Node<ResourceType>*> sorted_nodes_;
         bool modified_ = false;
@@ -470,51 +489,23 @@ class Graph {
         std::vector<size_t> sink_node_ids_;
 
         // CSR (Compressed Sparse Row) arc arrays — rebuilt by build_csr() / sort_nodes().
-        // Declared mutable so const accessor methods (get_out_arcs / get_in_arcs) can return
-        // non-const spans without requiring a const_cast at every call site.
         mutable std::vector<Arc<ResourceType>*> csr_out_arcs_;
         mutable std::vector<Arc<ResourceType>*> csr_in_arcs_;
         mutable bool csr_valid_ = false;
 
-        virtual typename ArcMap::iterator remove_arc(typename ArcMap::iterator it) {
-            size_t arc_id = it->first;
-            Arc<ResourceType>& arc = *it->second;
-
-            // remove arc from destination node's in_arcs
-            auto& in_arcs = arc.destination->in_arcs;
-            in_arcs.erase(
-                std::remove_if(in_arcs.begin(),
-                               in_arcs.end(),
-                               [arc_id](Arc<ResourceType>* a) { return a->id == arc_id; }),
-                in_arcs.end());
-
-            // remove arc from origin node's out_arcs
-            auto& out_arcs = arc.origin->out_arcs;
-            out_arcs.erase(
-                std::remove_if(out_arcs.begin(),
-                               out_arcs.end(),
-                               [arc_id](Arc<ResourceType>* a) { return a->id == arc_id; }),
-                out_arcs.end());
-
-            // move deleted arc
-            removed_arcs_by_id_.emplace(arc_id, std::move(it->second));
-            modified_ = true;
-            csr_valid_ = false;
-            // delete from arcs map
-            return arcs_by_id_.erase(it);
-        }
-
-        virtual typename ArcMap::iterator restore_arc(const typename ArcMap::iterator& it) {
+        // Internal helper: restore one arc while iterating removed_arcs_by_id_.
+        typename ArcMap::iterator restore_arc_from_map(typename ArcMap::iterator it) {
             Arc<ResourceType>* arc = it->second.get();
-            // add arc to destination node's in_arcs
             arc->destination->in_arcs.push_back(arc);
-            // add arc to origin node's out_arcs
             arc->origin->out_arcs.push_back(arc);
-            // move restored arc
-            arcs_by_id_.emplace(it->first, std::move(it->second));
+            size_t arc_id = it->first;
+            if (arc_id >= arcs_.size()) {
+                arcs_.resize(arc_id + 1);
+            }
+            arcs_[arc_id] = std::move(it->second);
+            ++active_arc_count_;
             modified_ = true;
             csr_valid_ = false;
-            // delete from deleted arcs map
             return removed_arcs_by_id_.erase(it);
         }
 };

--- a/src/rcspp/preprocessor/bellman_ford_algorithm.hpp
+++ b/src/rcspp/preprocessor/bellman_ford_algorithm.hpp
@@ -48,31 +48,31 @@ class BellmanFordAlgorithm {
 
             // Prepare distance table
             std::vector<ArcRelaxation> arc_relaxations;
-            for (const auto& [arc_id, arc] : graph_.get_arcs_by_id()) {
+            graph_.for_each_arc([&](const auto& arc) {
                 // fetch cost
-                // get the origin cost of the cost resource
                 if (cost_index.has_value()) {
+                    // get the origin cost of the cost resource
                     const auto& origin_cost_resource =
-                        arc->origin->resource->template get_component<CostResourceType>(
+                        arc.origin->resource->template get_component<CostResourceType>(
                             cost_index.value());
                     double origin_cost = origin_cost_resource.get_value().get_value();
                     // extend the resource
                     Resource<ResourceTypeComposition<ResourceTypes...>> resource(
-                        *arc->destination->resource);
-                    arc->extender->extend(*arc->origin->resource, &resource);
+                        *arc.destination->resource);
+                    arc.extender->extend(*arc.origin->resource, &resource);
                     // fetch the new value of the cost resource
                     const auto& cost_resource =
                         resource.template get_component<CostResourceType>(cost_index.value());
                     double cost = cost_resource.get_value().get_value();
                     // compute the weight, i.e., cost difference
-                    arc_relaxations.emplace_back(arc->origin->id,
-                                                 arc->destination->id,
+                    arc_relaxations.emplace_back(arc.origin->id,
+                                                 arc.destination->id,
                                                  cost - origin_cost);
                 } else {
                     // use default cost
-                    arc_relaxations.emplace_back(arc->origin->id, arc->destination->id, arc->cost);
+                    arc_relaxations.emplace_back(arc.origin->id, arc.destination->id, arc.cost);
                 }
-            }
+            });
 
             // In backward shortest path computation, we need to reverse the order of arc
             // relaxations to ensure that relaxation proceeds from destination to origin, correctly

--- a/src/rcspp/preprocessor/shortest_path_connectivity_sort.hpp
+++ b/src/rcspp/preprocessor/shortest_path_connectivity_sort.hpp
@@ -63,10 +63,9 @@ class ShortestPathConnectivitySort {
             std::unordered_map<std::pair<size_t, size_t>, size_t, DirectArcKeyHash>
                 direct_arc_count;
             direct_arc_count.reserve(graph->get_number_of_arcs());
-            for (const auto& arc_entry : graph->get_arcs_by_id()) {
-                const auto& arc_ptr = arc_entry.second;
-                ++direct_arc_count[{arc_ptr->origin->id, arc_ptr->destination->id}];
-            }
+            graph->for_each_arc([&](const auto& arc) {
+                ++direct_arc_count[{arc.origin->id, arc.destination->id}];
+            });
             auto get_direct_arc_count = [&](size_t origin_id, size_t destination_id) -> size_t {
                 auto it = direct_arc_count.find({origin_id, destination_id});
                 return it == direct_arc_count.end() ? 0 : it->second;

--- a/src/rcspp/resource/base/resource_factory.hpp
+++ b/src/rcspp/resource/base/resource_factory.hpp
@@ -96,6 +96,18 @@ class ResourceFactory {
             return new_resource;
         }
 
+        /// @brief Return a deep copy of this factory (prototype + extension function).
+        [[nodiscard]] virtual std::unique_ptr<ResourceFactory<ResourceType>> clone() const {
+            auto cloned = std::make_unique<ResourceFactory<ResourceType>>();
+            if (resource_prototype_) {
+                cloned->resource_prototype_ = resource_prototype_->clone();
+            }
+            if (extension_function_) {
+                cloned->extension_function_ = extension_function_->clone();
+            }
+            return cloned;
+        }
+
         // Make an extender
         template <typename GraphResourceType>
         auto create_extender(const Arc<GraphResourceType>& arc) -> std::unique_ptr<ExtenderClass> {

--- a/src/rcspp/resource/composition/resource_composition_factory.hpp
+++ b/src/rcspp/resource/composition/resource_composition_factory.hpp
@@ -42,6 +42,12 @@ class ResourceCompositionFactory
 
         ~ResourceCompositionFactory() override = default;
 
+        // The user-declared destructor suppresses the implicit move constructor/assignment.
+        // Explicitly default them so ResourceGraph's private constructor can move-construct
+        // resource_factory_.
+        ResourceCompositionFactory(ResourceCompositionFactory&&) = default;
+        ResourceCompositionFactory& operator=(ResourceCompositionFactory&&) = default;
+
         auto create_resource(size_t node_id) -> std::unique_ptr<ResourceClass> override {
             return Base::create_resource(node_id);
         }
@@ -145,6 +151,30 @@ class ResourceCompositionFactory
             constexpr size_t ResourceTypeIndex =
                 ComponentTypeIndex_v<ResourceType, ResourceTypes...>;
             return this->template get_components<ResourceTypeIndex>().size();
+        }
+
+        /// @brief Return a deep copy of this factory.
+        ///
+        /// Clones each per-type ResourceFactory (via the Composition copy constructor,
+        /// which calls clone() on every element) then rebuilds the composition-level
+        /// resource prototype from the cloned sub-factories.
+        [[nodiscard]] std::unique_ptr<ResourceCompositionFactory<ResourceTypes...>>
+        clone_factory() const {
+            // Construct with default composition functions so resource_prototype_ is
+            // valid before update_resource_prototype() is called.
+            auto new_factory = std::make_unique<ResourceCompositionFactory<ResourceTypes...>>(
+                std::make_unique<CompositionExtensionFunction<ResourceTypes...>>(),
+                std::make_unique<CompositionFeasibilityFunction<ResourceTypes...>>(),
+                std::make_unique<CompositionCostFunction<ResourceTypes...>>(),
+                std::make_unique<CompositionDominanceFunction<ResourceTypes...>>());
+            // Copy-assign the Composition<ResourceFactory, ResourceTypes...> part.
+            // The assignment triggers the copy constructor, which calls clone() on
+            // every ResourceFactory<RT> in the per-type vectors.
+            static_cast<Composition<ResourceFactory, ResourceTypes...>&>(*new_factory) =
+                static_cast<const Composition<ResourceFactory, ResourceTypes...>&>(*this);
+            // Rebuild resource_prototype_ from the newly cloned sub-factories.
+            new_factory->update_resource_prototype();
+            return new_factory;
         }
 
     private:

--- a/src/rcspp/resource/composition/resource_composition_factory.hpp
+++ b/src/rcspp/resource/composition/resource_composition_factory.hpp
@@ -158,8 +158,8 @@ class ResourceCompositionFactory
         /// Clones each per-type ResourceFactory (via the Composition copy constructor,
         /// which calls clone() on every element) then rebuilds the composition-level
         /// resource prototype from the cloned sub-factories.
-        [[nodiscard]] std::unique_ptr<ResourceCompositionFactory<ResourceTypes...>>
-        clone_factory() const {
+        [[nodiscard]] std::unique_ptr<ResourceCompositionFactory<ResourceTypes...>> clone_factory()
+            const {
             // Construct with default composition functions so resource_prototype_ is
             // valid before update_resource_prototype() is called.
             auto new_factory = std::make_unique<ResourceCompositionFactory<ResourceTypes...>>(

--- a/src/rcspp/resource/resource_graph.hpp
+++ b/src/rcspp/resource/resource_graph.hpp
@@ -187,6 +187,29 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
             return resource_factory_;
         }
 
+        /// @brief Return a deep copy of this ResourceGraph with stable arc IDs.
+        ///
+        /// Clones the resource factory (so the new graph has independent resource
+        /// prototypes and extension functions), then delegates topology copying to
+        /// Graph::clone_topology_into(), which:
+        ///  - creates nodes via ResourceGraph::add_node() (initialises resources from
+        ///    the cloned factory) and overrides with clones of the original resources;
+        ///  - copies arcs at their exact IDs using add_arc_at, then clones extenders.
+        ///
+        /// @param include_rows       Copy arc dual_rows (set false for topology-only clones).
+        /// @param clone_removed_arcs Also clone removed arcs (re-removed in the clone).
+        [[nodiscard]] std::unique_ptr<ResourceGraph<ResourceTypes...>> clone(
+            bool include_rows = true, bool clone_removed_arcs = false) const {
+            auto factory_clone = resource_factory_.clone_factory();
+            // Use raw new: clone() is a ResourceGraph member and can access the private
+            // constructor; std::make_unique cannot (it's an external template).
+            auto new_rg = std::unique_ptr<ResourceGraph<ResourceTypes...>>(
+                new ResourceGraph<ResourceTypes...>(std::move(*factory_clone)));
+            Graph<ResourceCompositionType>::clone_topology_into(
+                *new_rg, include_rows, clone_removed_arcs);
+            return new_rg;
+        }
+
         void update_arc(
             Arc<ResourceCompositionType>* arc,
             const std::tuple<std::vector<ComponentInitializerTypeTuple_t<ResourceTypes>>...>&
@@ -424,6 +447,10 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
         }
 
     private:
+        /// @brief Construct directly from a pre-built factory (used by clone()).
+        explicit ResourceGraph(ResourceCompositionFactory<ResourceTypes...>&& factory)
+            : resource_factory_(std::move(factory)), connectivityMatrix_(this) {}
+
         ResourceCompositionFactory<ResourceTypes...> resource_factory_;
         ConnectivityMatrix<ResourceCompositionType> connectivityMatrix_;
         std::mutex mutex_;

--- a/src/rcspp/resource/resource_graph.hpp
+++ b/src/rcspp/resource/resource_graph.hpp
@@ -409,19 +409,17 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
                 return;
             }
 
-            for (auto& [arc_id, arc_ptr] : this->get_arcs_by_id()) {
-                double reduced_cost = arc_ptr->cost;
-                for (const auto& dual_row : arc_ptr->dual_rows) {
+            this->for_each_arc([&](auto& arc) {
+                double reduced_cost = arc.cost;
+                for (const auto& dual_row : arc.dual_rows) {
                     // Out-of-range indices are treated as 0 so callers can pass a sparse
                     // (or empty) duals vector without sizing it to cover every arc.
                     const auto dual_value =
                         (dual_row.index < duals.size()) ? duals[dual_row.index] : 0.0;
-
                     reduced_cost -= dual_row.coefficient * dual_value;
                 }
-
-                update_arc<CostResourceType>(arc_ptr.get(), cost_index, reduced_cost);
-            }
+                update_arc<CostResourceType>(&arc, cost_index, reduced_cost);
+            });
         }
 
     private:

--- a/src/rcspp/resource/resource_graph.hpp
+++ b/src/rcspp/resource/resource_graph.hpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <memory>
 #include <mutex>  // NOLINT
+#include <stdexcept>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -412,11 +413,13 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
             this->for_each_arc([&](auto& arc) {
                 double reduced_cost = arc.cost;
                 for (const auto& dual_row : arc.dual_rows) {
-                    // Out-of-range indices are treated as 0 so callers can pass a sparse
-                    // (or empty) duals vector without sizing it to cover every arc.
-                    const auto dual_value =
-                        (dual_row.index < duals.size()) ? duals[dual_row.index] : 0.0;
-                    reduced_cost -= dual_row.coefficient * dual_value;
+                    if (dual_row.index >= duals.size()) {
+                        throw std::out_of_range(
+                            "ResourceGraph::update_reduced_costs: dual index " +
+                            std::to_string(dual_row.index) +
+                            " is out of range (duals.size()=" + std::to_string(duals.size()) + ")");
+                    }
+                    reduced_cost -= dual_row.coefficient * duals[dual_row.index];
                 }
                 update_arc<CostResourceType>(&arc, cost_index, reduced_cost);
             });

--- a/src/rcspp/resource/resource_graph.hpp
+++ b/src/rcspp/resource/resource_graph.hpp
@@ -142,11 +142,11 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
             const std::tuple<std::vector<ComponentInitializerTypeTuple_t<ResourceTypes>>...>&
                 resource_consumption,
             size_t origin_node_id, size_t destination_node_id, double cost = 0.0,
-            std::vector<Row> dual_rows = {}) {
+            std::vector<Row> rows = {}) {
             auto& arc = Graph<ResourceCompositionType>::add_arc(origin_node_id,
                                                                 destination_node_id,
                                                                 cost,
-                                                                dual_rows);
+                                                                rows);
 
             auto extender = resource_factory_.create_extender(resource_consumption, arc);
             arc.extender = std::move(extender);
@@ -158,7 +158,7 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
             const std::tuple<ComponentInitializerTypeTuple_t<ExtenderResourceTypes>...>&
                 extender_resource_consumption,
             size_t origin_node_id, size_t destination_node_id, double cost = 0.0,
-            std::vector<Row> dual_rows = {}) {
+            std::vector<Row> rows = {}) {
             // build the full resource consumption tuple from the extender resource consumption
             std::tuple<std::vector<ComponentInitializerTypeTuple_t<ResourceTypes>>...>
                 resource_consumption;
@@ -176,11 +176,7 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
             };  // NOLINT
             apply_indices(std::make_index_sequence<sizeof...(ExtenderResourceTypes)>{});
 
-            return add_arc(resource_consumption,
-                           origin_node_id,
-                           destination_node_id,
-                           cost,
-                           dual_rows);
+            return add_arc(resource_consumption, origin_node_id, destination_node_id, cost, rows);
         }
 
         ResourceCompositionFactory<ResourceTypes...>& get_resource_factory() {
@@ -196,7 +192,7 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
         ///    the cloned factory) and overrides with clones of the original resources;
         ///  - copies arcs at their exact IDs using add_arc_at, then clones extenders.
         ///
-        /// @param include_rows       Copy arc dual_rows (set false for topology-only clones).
+        /// @param include_rows       Copy arc rows (set false for topology-only clones).
         /// @param clone_removed_arcs Also clone removed arcs (re-removed in the clone).
         [[nodiscard]] std::unique_ptr<ResourceGraph<ResourceTypes...>> clone(
             bool include_rows = true, bool clone_removed_arcs = false) const {
@@ -205,8 +201,9 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
             // constructor; std::make_unique cannot (it's an external template).
             auto new_rg = std::unique_ptr<ResourceGraph<ResourceTypes...>>(
                 new ResourceGraph<ResourceTypes...>(std::move(*factory_clone)));
-            Graph<ResourceCompositionType>::clone_topology_into(
-                *new_rg, include_rows, clone_removed_arcs);
+            Graph<ResourceCompositionType>::clone_topology_into(*new_rg,
+                                                                include_rows,
+                                                                clone_removed_arcs);
             return new_rg;
         }
 
@@ -433,14 +430,14 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
 
             this->for_each_arc([&](auto& arc) {
                 double reduced_cost = arc.cost;
-                for (const auto& dual_row : arc.dual_rows) {
-                    if (dual_row.index >= duals.size()) {
+                for (const auto& row : arc.rows) {
+                    if (row.index >= duals.size()) {
                         throw std::out_of_range(
                             "ResourceGraph::update_reduced_costs: dual index " +
-                            std::to_string(dual_row.index) +
+                            std::to_string(row.index) +
                             " is out of range (duals.size()=" + std::to_string(duals.size()) + ")");
                     }
-                    reduced_cost -= dual_row.coefficient * duals[dual_row.index];
+                    reduced_cost -= row.coefficient * duals[row.index];
                 }
                 update_arc<CostResourceType>(&arc, cost_index, reduced_cost);
             });

--- a/src/rcspp/resource/resource_graph.hpp
+++ b/src/rcspp/resource/resource_graph.hpp
@@ -142,12 +142,11 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
             const std::tuple<std::vector<ComponentInitializerTypeTuple_t<ResourceTypes>>...>&
                 resource_consumption,
             size_t origin_node_id, size_t destination_node_id, double cost = 0.0,
-            std::vector<Row> dual_rows = {}, std::optional<size_t> arc_id = std::nullopt) {
+            std::vector<Row> dual_rows = {}) {
             auto& arc = Graph<ResourceCompositionType>::add_arc(origin_node_id,
                                                                 destination_node_id,
                                                                 cost,
-                                                                dual_rows,
-                                                                arc_id);
+                                                                dual_rows);
 
             auto extender = resource_factory_.create_extender(resource_consumption, arc);
             arc.extender = std::move(extender);
@@ -159,7 +158,7 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
             const std::tuple<ComponentInitializerTypeTuple_t<ExtenderResourceTypes>...>&
                 extender_resource_consumption,
             size_t origin_node_id, size_t destination_node_id, double cost = 0.0,
-            std::vector<Row> dual_rows = {}, std::optional<size_t> arc_id = std::nullopt) {
+            std::vector<Row> dual_rows = {}) {
             // build the full resource consumption tuple from the extender resource consumption
             std::tuple<std::vector<ComponentInitializerTypeTuple_t<ResourceTypes>>...>
                 resource_consumption;
@@ -181,8 +180,7 @@ class ResourceGraph : public Graph<ResourceTypeComposition<ResourceTypes...>> {
                            origin_node_id,
                            destination_node_id,
                            cost,
-                           dual_rows,
-                           arc_id);
+                           dual_rows);
         }
 
         ResourceCompositionFactory<ResourceTypes...>& get_resource_factory() {

--- a/tests/rcspp/CMakeLists.txt
+++ b/tests/rcspp/CMakeLists.txt
@@ -9,6 +9,8 @@ FetchContent_Declare(
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
+# Disable clang-tidy for GTest/GMock targets — they are third-party sources.
+set_target_properties(gtest gtest_main gmock gmock_main PROPERTIES CXX_CLANG_TIDY "")
 
 # Sources ---------------------------------------------------------------------
 file(GLOB_RECURSE TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")

--- a/tests/rcspp/vrp_subproblem/vrp_subproblem.cpp
+++ b/tests/rcspp/vrp_subproblem/vrp_subproblem.cpp
@@ -170,8 +170,7 @@ void VRPSubproblem::add_arc_to_graph(RGraph* resource_graph, size_t customer_ori
         customer_orig_id,
         customer_dest_id,
         distance,
-        {Row(customer_orig_id, row_coefficient)},
-        arc_id);
+        {Row(customer_orig_id, row_coefficient)});
 }
 
 double VRPSubproblem::calculate_distance(const Customer& customer1, const Customer& customer2) {


### PR DESCRIPTION
## Summary

  - **Vector arc storage**: replace `unordered_map<id, unique_ptr<Arc>>`
    with a flat `vector` indexed by arc ID (nullptr slots for removed arcs).
    Add `for_each_arc(F&&)` as the canonical zero-allocation iterator; use it
    consistently in `clone()`, `remove_arcs_if()`, and all callers.

  - **Arc ID ownership**: remove the `arc_id` parameter from all public
    `add_arc` overloads — IDs are now exclusively assigned by a monotonically
    increasing `next_arc_id_`. The Python `add_arc` returns the predicted
    future ID immediately (before flush), mirroring the C++ counter.

  - **`clone` / `clone_topology` API**: `ResourceGraph` gains `clone()`,
    `clone_topology()`, `add_rows_to_arc()`, `add_rows()`, and `next_arc_id()`
    on both the C++ and Python sides. Python `clone` preserves `_next_arc_id`
    from the C++ object. 30 new pytest tests cover all clone scenarios.

  - **`dual_rows` → `rows`**: rename `Arc::dual_rows` and all parameter names
    throughout C++ and Python (bindings, `graph.py`, `vrp.py`, tests).

  - **`update_reduced_costs` error**: replace the silent `0.0` fallback with
    `std::out_of_range` when a row index exceeds the duals vector.

  - **GIL**: release the GIL on longer C++ operations (bulk arc insertion,
    solve).

  ## Test plan

  - [x] C++ tests pass: `cmake --build … --target tests-rcspp && ctest`
  - [x] Python tests pass: `pytest src/python/`
  - [x] VRP benchmark builds: `cmake --build … --target rcspp-vrp-benchmark`
  - [x] `test_clone.py` (30 tests): clone, clone_topology, add_rows_to_arc,
        predicted arc IDs, remove/restore roundtrip
  - [x] `test_graph.py`: force_arc, remove/restore bulk, update_reduced_costs,
        predicted IDs