### PR TITLE
Poll timeout/interrupt/memory-limit inside dive loops; fix pulling should_stop

### DIFF
--- a/cpp/rcspp/algorithm/greedy.hpp
+++ b/cpp/rcspp/algorithm/greedy.hpp
@@ -90,7 +90,15 @@ class GreedyAlgorithm : public Algorithm<ResourceType, LabelContainerType> {
             // Note: do NOT keep a reference to path_.back() across pop_back() calls
             // (that'd be a dangling reference). Re-query path_.back() each loop.
             // try to extend the label greedily
+            //
+            // The sibling-switching backtrack below can enumerate many partial
+            // paths inside this single call, so poll should_stop() every 4096
+            // steps.
+            size_t steps = 0;
             while (!path_.empty()) {
+                if ((++steps & 0xFFFU) == 0 && this->should_stop()) {
+                    return;
+                }
                 bool extended = false;
                 while (extend_label(path_.back().first)) {
                     extended = true;  // successfully extended

--- a/cpp/rcspp/algorithm/greedy.hpp
+++ b/cpp/rcspp/algorithm/greedy.hpp
@@ -92,11 +92,12 @@ class GreedyAlgorithm : public Algorithm<ResourceType, LabelContainerType> {
             // try to extend the label greedily
             //
             // The sibling-switching backtrack below can enumerate many partial
-            // paths inside this single call, so poll should_stop() every 4096
-            // steps.
+            // paths inside this single call, so poll should_stop() and the
+            // memory limit every 4096 steps.
             size_t steps = 0;
             while (!path_.empty()) {
-                if ((++steps & 0xFFFU) == 0 && this->should_stop()) {
+                if ((++steps & 0xFFFU) == 0 &&
+                    (this->should_stop() || this->memory_limit_.is_exceeded())) {
                     return;
                 }
                 bool extended = false;

--- a/cpp/rcspp/algorithm/improving_tabu_search.hpp
+++ b/cpp/rcspp/algorithm/improving_tabu_search.hpp
@@ -213,7 +213,14 @@ class ImprovingTabuSearch : public BacktrackingDiveAlgorithm<ResourceType, Label
     private:
         // ─── helpers ─────────────────────────────────────────────────────────
         bool dive_to_sink() {
+            // A single dive can enumerate exponentially many partial paths
+            // between main_loop()'s per-iteration checks, so poll
+            // should_stop() every 4096 steps.
+            size_t steps = 0;
             while (!this->path_.empty()) {
+                if ((++steps & 0xFFFU) == 0 && this->should_stop()) {
+                    return false;
+                }
                 auto* current = this->path_.back().first;
                 if (current->get_end_node()->sink) {
                     return true;

--- a/cpp/rcspp/algorithm/improving_tabu_search.hpp
+++ b/cpp/rcspp/algorithm/improving_tabu_search.hpp
@@ -214,11 +214,13 @@ class ImprovingTabuSearch : public BacktrackingDiveAlgorithm<ResourceType, Label
         // ─── helpers ─────────────────────────────────────────────────────────
         bool dive_to_sink() {
             // A single dive can enumerate exponentially many partial paths
-            // between main_loop()'s per-iteration checks, so poll
-            // should_stop() every 4096 steps.
+            // between main_loop()'s per-iteration checks — and each extension
+            // allocates a label — so poll should_stop() and the memory limit
+            // every 4096 steps.
             size_t steps = 0;
             while (!this->path_.empty()) {
-                if ((++steps & 0xFFFU) == 0 && this->should_stop()) {
+                if ((++steps & 0xFFFU) == 0 &&
+                    (this->should_stop() || this->memory_limit_.is_exceeded())) {
                     return false;
                 }
                 auto* current = this->path_.back().first;

--- a/cpp/rcspp/algorithm/pulling_dominance_algorithm.hpp
+++ b/cpp/rcspp/algorithm/pulling_dominance_algorithm.hpp
@@ -32,7 +32,7 @@ class PullingDominanceAlgorithm : public DominanceAlgorithm<ResourceType, LabelC
 
         void main_loop() override {  // NOLINT
             size_t i = 0;
-            while (number_of_labels() > 0 && i < this->params_.max_iterations) {
+            while (number_of_labels() > 0 && !this->should_stop(i)) {
                 // Periodic memory check (pulling: each iteration processes one node).
                 if (i > 0 && this->memory_limit_.effective_limit > 0 &&
                     i % this->params_.memory_check_interval == 0) {

--- a/cpp/rcspp/algorithm/tabu_search.hpp
+++ b/cpp/rcspp/algorithm/tabu_search.hpp
@@ -140,11 +140,13 @@ class TabuSearchAlgorithm : public BacktrackingDiveAlgorithm<ResourceType, Label
 
         bool dive_to_sink() {
             // A single dive can enumerate exponentially many partial paths
-            // between main_loop()'s per-iteration checks, so poll
-            // should_stop() every 4096 steps.
+            // between main_loop()'s per-iteration checks — and each extension
+            // allocates a label — so poll should_stop() and the memory limit
+            // every 4096 steps.
             size_t steps = 0;
             while (!this->path_.empty()) {
-                if ((++steps & 0xFFFU) == 0 && this->should_stop()) {
+                if ((++steps & 0xFFFU) == 0 &&
+                    (this->should_stop() || this->memory_limit_.is_exceeded())) {
                     return false;
                 }
                 auto* current = this->path_.back().first;

--- a/cpp/rcspp/algorithm/tabu_search.hpp
+++ b/cpp/rcspp/algorithm/tabu_search.hpp
@@ -139,7 +139,14 @@ class TabuSearchAlgorithm : public BacktrackingDiveAlgorithm<ResourceType, Label
         // ------------------------------------------------------------------
 
         bool dive_to_sink() {
+            // A single dive can enumerate exponentially many partial paths
+            // between main_loop()'s per-iteration checks, so poll
+            // should_stop() every 4096 steps.
+            size_t steps = 0;
             while (!this->path_.empty()) {
+                if ((++steps & 0xFFFU) == 0 && this->should_stop()) {
+                    return false;
+                }
                 auto* current = this->path_.back().first;
                 if (current->get_end_node()->sink) {
                     return true;


### PR DESCRIPTION
## Summary

Two fixes for pathological solves that can wedge a caller for minutes inside a single `solve()` call.

### 1. Poll should_stop() inside dive loops (7ca2273d)

A dive is a DFS with backtracking: on pathological instances a single dive can enumerate exponentially many partial paths, while all per-iteration `should_stop()` checks sit between dives — so `timeout_s` and the external interrupt never fire. The dive loops in `GreedyAlgorithm`, `TabuSearchAlgorithm`, and `ImprovingTabuSearch` now poll `should_stop()` every 4096 steps.

Also fixes `PullingDominanceAlgorithm::main_loop`, which historically only checked the iteration budget: it now uses `should_stop(i)`, which covers the budget plus `timeout_s` and the external interrupt, like the base `DominanceAlgorithm`.

### 2. Poll the memory limit inside dive loops (b5665b5e)

Each dive extension allocates a label, so a pathological dive is an RSS runaway as well as a time sink — and only the dominance main loops consulted `MemoryLimitHelper`. The same 4096-step poll now also checks `memory_limit_.is_exceeded()`. The memory check stays out of `should_stop()` itself on purpose: reading process RSS is a real syscall, and `should_stop()` runs every iteration of the hot dominance loops (which sample memory on their own throttled `memory_check_interval` cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
